### PR TITLE
docs: Add discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/leptos.svg)](https://crates.io/crates/leptos)
 [![docs.rs](https://docs.rs/leptos/badge.svg)](https://docs.rs/leptos)
-[Discord](https://discord.gg/wkwyyzGGj5)
+[![Discord](https://img.shields.io/discord/1031524867910148188?color=%237289DA&label=discord)](https://discord.gg/wkwyyzGGj5)
 
 # Leptos
 


### PR DESCRIPTION
This badge requires enabling the Widget setting on the Discord server. See a video tutorial here: https://vimeo.com/364220040?embedded=true&source=video_title&owner=103573672