### PR TITLE
Remove wee_alloc dependency

### DIFF
--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -15,7 +15,6 @@ leptos_reactive = { path = "../leptos_reactive", version = "0.0.8" }
 serde_json = { version = "1", optional = true }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.31"
-wee_alloc = "0.4.5"
 log = "0.4"
 
 [dependencies.web-sys]


### PR DESCRIPTION
wee_alloc has a security advisory ([RUSTSEC-2022-0054](https://rustsec.org/advisories/RUSTSEC-2022-0054)). It looks like you recently removed it from the examples, this just finishes the job by removing it from the leptos_dom cargo.toml since it's not actually in use.