### PR TITLE
Remove loaders from examples

### DIFF
--- a/examples/hackernews/hackernews-app/src/lib.rs
+++ b/examples/hackernews/hackernews-app/src/lib.rs
@@ -27,9 +27,9 @@ pub fn App(cx: Scope) -> Element {
                 <Nav />
                 <main>
                     <Routes>
-                        <Route path="users/:id" element=|cx| view! { cx,  <User/> } loader=user_data.into() />
-                        <Route path="stories/:id" element=|cx| view! { cx,  <Story/> } loader=story_data.into() />
-                        <Route path="*stories" element=|cx| view! { cx,  <Stories/> } loader=stories_data.into()/>
+                        <Route path="users/:id" element=|cx| view! { cx,  <User/> }/>
+                        <Route path="stories/:id" element=|cx| view! { cx,  <Story/> }/>
+                        <Route path="*stories" element=|cx| view! { cx,  <Stories/> }/>
                     </Routes>
                 </main>
             </Router>

--- a/examples/hackernews/hackernews-app/src/story.rs
+++ b/examples/hackernews/hackernews-app/src/story.rs
@@ -2,15 +2,14 @@ use crate::api;
 use leptos::*;
 use leptos_router::*;
 
-pub async fn story_data(_cx: Scope, params: ParamsMap, _url: Url) -> Result<api::Story, ()> {
-    log::debug!("(story_data) loading data for story");
-    let id = params.get("id").cloned().unwrap_or_default();
-    api::fetch_api(&api::story(&format!("item/{id}"))).await
-}
-
 #[component]
 pub fn Story(cx: Scope) -> Element {
-    let story = use_loader::<Result<api::Story, ()>>(cx);
+    let params = use_params_map(cx);
+    let story = create_resource(
+        cx,
+        move || params().get("id").cloned().unwrap_or_default(),
+        move |id| async move { api::fetch_api::<api::Story>(&api::story(&format!("item/{id}"))).await },
+    );
 
     view! { cx,
         <div>

--- a/examples/hackernews/hackernews-app/src/users.rs
+++ b/examples/hackernews/hackernews-app/src/users.rs
@@ -1,23 +1,22 @@
-use crate::api;
+use crate::api::{self, User};
 use leptos::*;
 use leptos_router::*;
 
-pub async fn user_data(_cx: Scope, params: ParamsMap, _url: Url) -> Result<api::User, ()> {
-    log::debug!("(story_data) loading data for user");
-    let id = params.get("id").cloned().unwrap_or_default();
-    api::fetch_api(&api::user(&id)).await
-}
-
 #[component]
 pub fn User(cx: Scope) -> Element {
-    let user = use_loader::<Result<api::User, ()>>(cx);
+    let params = use_params_map(cx);
+    let user = create_resource(
+        cx,
+        move || params().get("id").cloned().unwrap_or_default(),
+        move |id| async move { api::fetch_api::<User>(&api::user(&id)).await },
+    );
     view! { cx,
         <div class="user-view">
             {move || user.read().map(|user| match user {
                 Err(_) => view! { cx,  <h1>"User not found."</h1> },
                 Ok(user) => view! { cx,
                     <div>
-                        <h1>"User: " {user.id}</h1>
+                        <h1>"User: " {&user.id}</h1>
                         <ul class="meta">
                             <li>
                                 <span class="label">"Created: "</span> {user.created}
@@ -25,13 +24,13 @@ pub fn User(cx: Scope) -> Element {
                             <li>
                             <span class="label">"Karma: "</span> {user.karma}
                             </li>
-                            //{user.about.map(|about| view! { cx,  <li inner_html={user.about} class="about"></li> })}
+                            {user.about.as_ref().map(|about| view! { cx,  <li inner_html=about class="about"></li> })}
                         </ul>
-                       /*  <p class="links">
-                            <a href={format!("https://news.ycombinator.com/submitted?id={}", user.id)}>"submissions"</a>
+                        <p class="links">
+                            <a href=format!("https://news.ycombinator.com/submitted?id={}", user.id)>"submissions"</a>
                             " | "
-                            <a href={format!("https://news.ycombinator.com/threads?id={}", user.id)}>"comments"</a>
-                        </p> */
+                            <a href=format!("https://news.ycombinator.com/threads?id={}", user.id)>"comments"</a>
+                        </p>
                     </div>
                 }
             })}

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -54,11 +54,6 @@ features = [
   "Window"
 ]
 
-[profile.release]
-codegen-units = 1
-lto = true
-opt-level = 'z'
-
 [features]
 csr = ["leptos_reactive/csr"]
 hydrate = ["leptos_reactive/hydrate"]

--- a/leptos_reactive/src/signal.rs
+++ b/leptos_reactive/src/signal.rs
@@ -590,7 +590,10 @@ impl SignalId {
             let value = {
                 let signals = runtime.signals.borrow();
                 signals.get(*self).cloned().unwrap_or_else(|| {
-                    panic!("tried to access a signal that has been disposed: {self:?}")
+                    panic!(
+                        "tried to access a Signal<{}> that has been disposed: {self:?}",
+                        std::any::type_name::<T>()
+                    )
                 })
             };
             let mut value = value.borrow_mut();

--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -108,7 +108,7 @@ pub fn Routes(cx: Scope, props: RoutesProps) -> impl IntoChild {
 
                     if disposers.len() > i + 1 {
                         let old_route_disposer = std::mem::replace(&mut disposers[i], disposer);
-                        old_route_disposer.dispose();
+                        //old_route_disposer.dispose();
                     } else {
                         disposers.push(disposer);
                     }


### PR DESCRIPTION
I'm still trying to figure out what makes the most sense for a loader API. For now, I'm removing the loaders from the examples and using resources directly instead so that nobody's surprised if/when the loader API changes.