### PR TITLE
Remove clone bounds

### DIFF
--- a/examples/counters-stable/src/main.rs
+++ b/examples/counters-stable/src/main.rs
@@ -33,7 +33,7 @@ pub fn Counters(cx: Scope) -> web_sys::Element {
             let signal = create_signal(cx, 0);
             new_counters.push((next_id, signal));
         }
-        set_counters.set(new_counters.clone());
+        set_counters.update(|counters| counters.extend(new_counters.iter()));
     };
 
     let clear_counters = move |_| {

--- a/examples/counters/src/lib.rs
+++ b/examples/counters/src/lib.rs
@@ -27,7 +27,7 @@ pub fn Counters(cx: Scope) -> web_sys::Element {
             let signal = create_signal(cx, 0);
             new_counters.push((next_id, signal));
         }
-        set_counters(new_counters.clone());
+        set_counters.update(move |counters| counters.extend(new_counters.iter()));
     };
 
     let clear_counters = move |_| {

--- a/leptos_core/src/for_component.rs
+++ b/leptos_core/src/for_component.rs
@@ -15,7 +15,7 @@ where
     G: Fn(Scope, &T) -> Element,
     I: Fn(&T) -> K,
     K: Eq + Hash,
-    T: Eq + Clone + 'static,
+    T: Eq + 'static,
 {
     pub each: E,
     pub key: I,
@@ -34,7 +34,7 @@ where
     G: Fn(Scope, &T) -> Element + 'static,
     I: Fn(&T) -> K + 'static,
     K: Eq + Hash,
-    T: Eq + Clone + Debug + 'static,
+    T: Eq + Debug + 'static,
 {
     let map_fn = (props.children)().swap_remove(0);
     map_keyed(cx, props.each, map_fn, props.key)

--- a/leptos_core/src/map.rs
+++ b/leptos_core/src/map.rs
@@ -30,11 +30,11 @@ where
     // Previous state used for diffing.
     let mut disposers: Vec<Option<ScopeDisposer>> = Vec::new();
     let mut prev_items: Option<Vec<T>> = None;
-    //let mapped: Vec<U> = Vec::new();
+    let mut mapped: Vec<U> = Vec::new();
 
     // Diff and update signal each time list is updated.
-    create_memo(cx, move |mapped: Option<&Vec<U>>| {
-        let mut mapped = mapped.cloned().unwrap_or_default();
+    create_memo(cx, move |_| {
+        //let mut mapped = mapped.cloned().unwrap_or_default();
         let items = prev_items.take().unwrap_or_default();
         let new_items = list();
         let new_items_len = new_items.len();

--- a/leptos_core/src/map.rs
+++ b/leptos_core/src/map.rs
@@ -23,7 +23,7 @@ pub fn map_keyed<T, U, K>(
 ) -> Memo<Vec<U>>
 //-> impl FnMut() -> Vec<U>
 where
-    T: PartialEq + Debug + Clone + 'static,
+    T: PartialEq + Debug + 'static,
     K: Eq + Hash,
     U: PartialEq + Debug + Clone + 'static,
 {
@@ -33,8 +33,8 @@ where
     //let mapped: Vec<U> = Vec::new();
 
     // Diff and update signal each time list is updated.
-    create_memo(cx, move |mapped: Option<Vec<U>>| {
-        let mut mapped = mapped.unwrap_or_default();
+    create_memo(cx, move |mapped: Option<&Vec<U>>| {
+        let mut mapped = mapped.cloned().unwrap_or_default();
         let items = prev_items.take().unwrap_or_default();
         let new_items = list();
         let new_items_len = new_items.len();

--- a/leptos_reactive/src/memo.rs
+++ b/leptos_reactive/src/memo.rs
@@ -54,9 +54,9 @@ use std::fmt::Debug;
 /// });
 /// # }).dispose();
 /// ```
-pub fn create_memo<T>(cx: Scope, f: impl FnMut(Option<T>) -> T + 'static) -> Memo<T>
+pub fn create_memo<T>(cx: Scope, f: impl FnMut(Option<&T>) -> T + 'static) -> Memo<T>
 where
-    T: PartialEq + Clone + Debug + 'static,
+    T: PartialEq + Debug + 'static,
 {
     cx.runtime.create_memo(f)
 }
@@ -98,6 +98,10 @@ where
     pub(crate) fn try_with<U>(&self, f: impl Fn(&T) -> U) -> Result<U, SignalError> {
         self.0
             .try_with(|n| f(n.as_ref().expect("Memo is missing its initial value")))
+    }
+
+    pub(crate) fn subscribe(&self) {
+        self.0.subscribe()
     }
 }
 

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -315,6 +315,12 @@ where
     S: Debug + Clone + 'static,
     T: Debug + 'static,
 {
+    /// Clones and returns the current value of the resource ([Option::None] if the
+    /// resource is still pending). Also subscribes the running effect to this
+    /// resource.
+    ///
+    /// If you want to get the value without cloning it, use [Resource::with].
+    /// (`value.read()` is equivalent to `value.with(T::clone)`.)
     pub fn read(&self) -> Option<T>
     where
         T: Clone,
@@ -323,6 +329,13 @@ where
             .resource(self.id, |resource: &ResourceState<S, T>| resource.read())
     }
 
+    /// Applies a function to the current value of the resource, and subscribes
+    /// the running effect to this resource. If the resource hasn't yet
+    /// resolved, the function won't be called and this will return
+    /// [Option::None].
+    ///
+    /// If you want to get the value by cloning it, you can use
+    /// [Resource::read].
     pub fn with<U>(&self, f: impl FnOnce(&T) -> U) -> Option<U> {
         self.runtime
             .resource(self.id, |resource: &ResourceState<S, T>| resource.with(f))

--- a/leptos_reactive/src/signal.rs
+++ b/leptos_reactive/src/signal.rs
@@ -128,6 +128,14 @@ where
         self.id.with(self.runtime, f)
     }
 
+    pub(crate) fn with_no_subscription<U>(&self, f: impl FnOnce(&T) -> U) -> U {
+        self.id.with_no_subscription(self.runtime, f)
+    }
+
+    pub(crate) fn subscribe(&self) {
+        self.id.subscribe(self.runtime);
+    }
+
     /// Clones and returns the current value of the signal, and subscribes
     /// the running effect to this signal.
     ///
@@ -245,7 +253,7 @@ where
 
 impl<T> WriteSignal<T>
 where
-    T: Clone + 'static,
+    T: 'static,
 {
     /// Applies a function to the current value to mutate it in place
     /// and notifies subscribers that the signal has changed.
@@ -295,10 +303,7 @@ where
     }
 }
 
-impl<T> Clone for WriteSignal<T>
-where
-    T: Clone,
-{
+impl<T> Clone for WriteSignal<T> {
     fn clone(&self) -> Self {
         Self {
             runtime: self.runtime,
@@ -308,7 +313,7 @@ where
     }
 }
 
-impl<T> Copy for WriteSignal<T> where T: Clone {}
+impl<T> Copy for WriteSignal<T> {}
 
 #[cfg(not(feature = "stable"))]
 impl<T> FnOnce<(T,)> for WriteSignal<T>
@@ -436,6 +441,14 @@ where
     /// ```
     pub fn with<U>(&self, f: impl FnOnce(&T) -> U) -> U {
         self.id.with(self.runtime, f)
+    }
+
+    pub(crate) fn with_no_subscription<U>(&self, f: impl FnOnce(&T) -> U) -> U {
+        self.id.with_no_subscription(self.runtime, f)
+    }
+
+    pub(crate) fn subscribe(&self) {
+        self.id.subscribe(self.runtime);
     }
 
     /// Clones and returns the current value of the signal, and subscribes
@@ -567,14 +580,7 @@ pub(crate) enum SignalError {
 }
 
 impl SignalId {
-    pub(crate) fn try_with<T, U>(
-        &self,
-        runtime: &Runtime,
-        f: impl FnOnce(&T) -> U,
-    ) -> Result<U, SignalError>
-    where
-        T: 'static,
-    {
+    pub(crate) fn subscribe(&self, runtime: &Runtime) {
         // add subscriber
         if let Some(observer) = runtime.observer.get() {
             let mut subs = runtime.signal_subscribers.borrow_mut();
@@ -582,7 +588,16 @@ impl SignalId {
                 subs.or_default().borrow_mut().insert(observer);
             }
         }
+    }
 
+    pub(crate) fn try_with_no_subscription<T, U>(
+        &self,
+        runtime: &Runtime,
+        f: impl FnOnce(&T) -> U,
+    ) -> Result<U, SignalError>
+    where
+        T: 'static,
+    {
         // get the value
         let value = {
             let signals = runtime.signals.borrow();
@@ -599,6 +614,26 @@ impl SignalId {
             .downcast_ref::<T>()
             .ok_or_else(|| SignalError::Type(std::any::type_name::<T>()))?;
         Ok(f(value))
+    }
+
+    pub(crate) fn try_with<T, U>(
+        &self,
+        runtime: &Runtime,
+        f: impl FnOnce(&T) -> U,
+    ) -> Result<U, SignalError>
+    where
+        T: 'static,
+    {
+        self.subscribe(runtime);
+
+        self.try_with_no_subscription(runtime, f)
+    }
+
+    pub(crate) fn with_no_subscription<T, U>(&self, runtime: &Runtime, f: impl FnOnce(&T) -> U) -> U
+    where
+        T: 'static,
+    {
+        self.try_with_no_subscription(runtime, f).unwrap()
     }
 
     pub(crate) fn with<T, U>(&self, runtime: &Runtime, f: impl FnOnce(&T) -> U) -> U

--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -46,7 +46,7 @@ pub fn Routes(cx: Scope, props: RoutesProps) -> impl IntoChild {
 
     let route_states: Memo<RouterState> = create_memo(cx, {
         let root_equal = root_equal.clone();
-        move |prev: Option<RouterState>| {
+        move |prev: Option<&RouterState>| {
             root_equal.set(true);
             next.borrow_mut().clear();
 
@@ -154,7 +154,7 @@ pub fn Routes(cx: Scope, props: RoutesProps) -> impl IntoChild {
             if prev.is_none() || !root_equal.get() {
                 root.as_ref().map(|route| route.outlet().into_child(cx))
             } else {
-                prev.clone().unwrap()
+                prev.cloned().unwrap()
             }
         })
     })

--- a/router/src/data/action.rs
+++ b/router/src/data/action.rs
@@ -15,7 +15,7 @@ impl Action {
 
 impl<F, Fu> From<F> for Action
 where
-    F: Fn(&Request) -> Fu + Clone + 'static,
+    F: Fn(&Request) -> Fu + 'static,
     Fu: Future<Output = Response> + 'static,
 {
     fn from(f: F) -> Self {

--- a/router/src/history/location.rs
+++ b/router/src/history/location.rs
@@ -5,12 +5,12 @@ use crate::{State, Url};
 use super::params::ParamsMap;
 
 pub fn create_location(cx: Scope, path: ReadSignal<String>, state: ReadSignal<State>) -> Location {
-    let url = create_memo(cx, move |prev: Option<Url>| {
+    let url = create_memo(cx, move |prev: Option<&Url>| {
         path.with(|path| match Url::try_from(path.as_str()) {
             Ok(url) => url,
             Err(e) => {
                 log::error!("[Leptos Router] Invalid path {path}\n\n{e:?}");
-                prev.clone().unwrap()
+                prev.cloned().unwrap()
             }
         })
     });

--- a/router/src/hooks.rs
+++ b/router/src/hooks.rs
@@ -26,7 +26,7 @@ pub fn use_location(cx: Scope) -> Location {
 
 pub fn use_params<T: Params>(cx: Scope) -> Memo<Result<T, RouterError>>
 where
-    T: PartialEq + std::fmt::Debug + Clone,
+    T: PartialEq + std::fmt::Debug,
 {
     let route = use_route(cx);
     create_memo(cx, move |_| route.params().with(T::from_map))
@@ -39,7 +39,7 @@ pub fn use_params_map(cx: Scope) -> Memo<ParamsMap> {
 
 pub fn use_query<T: Params>(cx: Scope) -> Memo<Result<T, RouterError>>
 where
-    T: PartialEq + std::fmt::Debug + Clone,
+    T: PartialEq + std::fmt::Debug,
 {
     let router = use_router(cx);
     create_memo(cx, move |_| {


### PR DESCRIPTION
As mentioned in #36, this removes every `Clone` bound that didn't seem necessary. The main notes are:
- Types held in a Signal no longer need to be Clone
- The output type of a Resource's future no longer needs to be Clone, though the bounds for the source type are unchanged
- A `Resource::with()` method was added, with similar behavior to `Signal::with()` to allow access without cloning
- Memo output types do not need to be Clone
   - To accommodate this, Memo now takes `impl FnMut(Option<&T>) -> T` instead of `impl FnMut(Option<T>) -> T` which is a breaking change, albeit a minor one

This still needs some documentation updates which I'll hopefully get to tomorrow. I'll probably also drop the webcam component that spawned this PR and #35 in as an example unless you object. Tested with all of the examples, but let me know if you see any issues.