### PR TITLE
Make base libs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,28 +11,9 @@ members = [
   # libraries
   "meta",
   "router",
+]
 
-  # examples
-  "examples/counter",
-  "examples/counter-isomorphic/client",
-  "examples/counter-isomorphic/server",
-  "examples/counter-isomorphic/counter",
-  "examples/counters",
-  "examples/counters-stable",
-  "examples/fetch",
-  "examples/gtk",
-  "examples/hackernews/hackernews-app",
-  "examples/hackernews/hackernews-client",
-  "examples/hackernews/hackernews-server",
-  "examples/parent-child",
-  "examples/router",
-  "examples/todomvc",
-  "examples/todomvc-ssr/todomvc-ssr-client",
-  "examples/todomvc-ssr/todomvc-ssr-server",
-]
-exclude = [
-  "benchmarks"
-]
+exclude = ["examples/*", "benchmarks"]
 
 
 [profile.release]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,29 @@
+############
+# A make file for cargo-make, please install it with:
+#     cargo install --force cargo-make
+############
+
+[config]
+# make tasks run at the workspace root
+default_to_workspace = false
+
+[tasks.ci]
+dependencies = ["build", "test"]
+
+[tasks.build]
+clear = true
+dependencies = ["build-all"]
+
+[tasks.build-all]
+command = "cargo"
+args = ["+nightly", "build-all-features"]
+install_crate = "cargo-all-features"
+
+[tasks.test]
+clear = true
+dependencies = ["test-all"]
+
+[tasks.test-all]
+command = "cargo"
+args = ["+nightly", "test-all-features"]
+install_crate = "cargo-all-features"

--- a/examples/counter-isomorphic/client/Cargo.toml
+++ b/examples/counter-isomorphic/client/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "counter-client"
 version = "0.1.0"
@@ -8,9 +10,13 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 console_log = "0.2"
-leptos = { path = "../../../leptos", default-features = false, features = ["hydrate", "serde"] }
-counter-isomorphic = { path = "../counter",  default-features = false, features = ["hydrate"] }
+leptos = { path = "../../../leptos", default-features = false, features = [
+  "hydrate",
+  "serde",
+] }
+counter-isomorphic = { path = "../counter", default-features = false, features = [
+  "hydrate",
+] }
 log = "0.4"
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1.7"
-

--- a/examples/counter-isomorphic/counter/Cargo.toml
+++ b/examples/counter-isomorphic/counter/Cargo.toml
@@ -1,10 +1,14 @@
+[workspace]
+
 [package]
 name = "counter-isomorphic"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { path = "../../../leptos", default-features = false, features = ["serde"] }
+leptos = { path = "../../../leptos", default-features = false, features = [
+  "serde",
+] }
 leptos_router = { path = "../../../router", default-features = false }
 broadcaster = "1"
 console_log = "0.2"

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "counter"
 version = "0.1.0"
@@ -11,4 +13,3 @@ console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
-

--- a/examples/counters-stable/Cargo.toml
+++ b/examples/counters-stable/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "counters_stable"
 version = "0.1.0"
@@ -11,4 +13,3 @@ console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
-

--- a/examples/counters/Cargo.toml
+++ b/examples/counters/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "counters"
 version = "0.1.0"
@@ -11,4 +13,3 @@ console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
-

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "fetch"
 version = "0.1.0"
@@ -14,4 +16,3 @@ console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
-

--- a/examples/gtk/Cargo.toml
+++ b/examples/gtk/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "gtk"
 version = "0.1.0"

--- a/examples/hackernews/hackernews-app/Cargo.toml
+++ b/examples/hackernews/hackernews-app/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "hackernews-app"
 version = "0.1.0"
@@ -6,7 +8,9 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 console_log = "0.2"
-leptos = { path = "../../../leptos", default-features = false, features = ["serde"] }
+leptos = { path = "../../../leptos", default-features = false, features = [
+  "serde",
+] }
 leptos_meta = { path = "../../../meta", default-features = false }
 leptos_router = { path = "../../../router", default-features = false }
 log = "0.4"

--- a/examples/hackernews/hackernews-client/Cargo.toml
+++ b/examples/hackernews/hackernews-client/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "hackernews-client"
 version = "0.1.0"
@@ -9,6 +11,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 console_log = "0.2"
 console_error_panic_hook = "0.1"
-hackernews-app = { path = "../hackernews-app", default-features = false, features = ["hydrate"] }
-leptos = { path = "../../../leptos", default-features = false, features = ["hydrate", "serde"] }
+hackernews-app = { path = "../hackernews-app", default-features = false, features = [
+  "hydrate",
+] }
+leptos = { path = "../../../leptos", default-features = false, features = [
+  "hydrate",
+  "serde",
+] }
 log = "0.4"

--- a/examples/hackernews/hackernews-server/Cargo.toml
+++ b/examples/hackernews/hackernews-server/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "hackernews-server"
 version = "0.1.0"
@@ -7,11 +9,20 @@ edition = "2021"
 actix-files = "0.6"
 actix-web = { version = "4", features = ["openssl", "macros"] }
 futures = "0.3"
-leptos = { path = "../../../leptos", default-features = false, features = ["ssr", "serde"] }
-leptos_router = { path = "../../../router", default-features = false, features = ["ssr"] }
-leptos_meta = { path = "../../../meta", default-features = false, features = ["ssr"] }
+leptos = { path = "../../../leptos", default-features = false, features = [
+  "ssr",
+  "serde",
+] }
+leptos_router = { path = "../../../router", default-features = false, features = [
+  "ssr",
+] }
+leptos_meta = { path = "../../../meta", default-features = false, features = [
+  "ssr",
+] }
 log = "0.4"
-hackernews-app = { path = "../hackernews-app", default-features = false, features = ["ssr"] }
+hackernews-app = { path = "../hackernews-app", default-features = false, features = [
+  "ssr",
+] }
 openssl = { version = "0.10", features = ["v110"] }
 simple_logger = "2"
 serde_json = "1.0.85"

--- a/examples/parent-child/Cargo.toml
+++ b/examples/parent-child/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "parent-child"
 version = "0.1.0"
@@ -8,4 +10,3 @@ leptos = { path = "../../leptos" }
 console_log = "0.2"
 log = "0.4"
 console_error_panic_hook = "0.1.7"
-

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "router"
 version = "0.1.0"
@@ -14,4 +16,3 @@ console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
-

--- a/examples/todomvc-ssr/todomvc-ssr-client/Cargo.toml
+++ b/examples/todomvc-ssr/todomvc-ssr-client/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "todomvc-ssr-client"
 version = "0.1.0"
@@ -8,9 +10,12 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 console_log = "0.2"
-leptos = { path = "../../../leptos", default-features = false, features = ["hydrate"] }
-todomvc = { path = "../../todomvc",  default-features = false, features = ["hydrate"] }
+leptos = { path = "../../../leptos", default-features = false, features = [
+  "hydrate",
+] }
+todomvc = { path = "../../todomvc", default-features = false, features = [
+  "hydrate",
+] }
 log = "0.4"
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1.7"
-

--- a/examples/todomvc-ssr/todomvc-ssr-server/Cargo.toml
+++ b/examples/todomvc-ssr/todomvc-ssr-server/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "todomvc-ssr-server"
 version = "0.1.0"
@@ -6,5 +8,9 @@ edition = "2021"
 [dependencies]
 actix-files = "0.6"
 actix-web = "4"
-leptos = { path = "../../../leptos", default-features = false, features = ["ssr"] }
-todomvc = { path = "../../todomvc", default-features = false, features = ["ssr"] }
+leptos = { path = "../../../leptos", default-features = false, features = [
+  "ssr",
+] }
+todomvc = { path = "../../todomvc", default-features = false, features = [
+  "ssr",
+] }

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "todomvc"
 version = "0.1.0"

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -17,10 +17,38 @@ leptos_server = { path = "../leptos_server", default-features = false, version =
 
 [features]
 default = ["csr", "serde"]
-csr = ["leptos_core/csr", "leptos_dom/csr", "leptos_macro/csr", "leptos_reactive/csr", "leptos_server/csr"]
-hydrate = ["leptos_core/hydrate", "leptos_dom/hydrate", "leptos_macro/hydrate", "leptos_reactive/hydrate", "leptos_server/hydrate"]
-ssr = ["leptos_core/ssr", "leptos_dom/ssr", "leptos_macro/ssr", "leptos_reactive/ssr", "leptos_server/ssr"]
-stable = ["leptos_core/stable", "leptos_dom/stable", "leptos_macro/stable", "leptos_reactive/stable", "leptos_server/stable"]
+csr = [
+  "leptos_core/csr",
+  "leptos_dom/csr",
+  "leptos_macro/csr",
+  "leptos_reactive/csr",
+  "leptos_server/csr",
+]
+hydrate = [
+  "leptos_core/hydrate",
+  "leptos_dom/hydrate",
+  "leptos_macro/hydrate",
+  "leptos_reactive/hydrate",
+  "leptos_server/hydrate",
+]
+ssr = [
+  "leptos_core/ssr",
+  "leptos_dom/ssr",
+  "leptos_macro/ssr",
+  "leptos_reactive/ssr",
+  "leptos_server/ssr",
+]
+stable = [
+  "leptos_core/stable",
+  "leptos_dom/stable",
+  "leptos_macro/stable",
+  "leptos_reactive/stable",
+  "leptos_server/stable",
+]
 serde = ["leptos_reactive/serde"]
 serde-lite = ["leptos_reactive/serde-lite"]
 miniserde = ["leptos_reactive/miniserde"]
+
+[package.metadata.cargo-all-features]
+# mutually exclusive features
+skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["hydrate", "ssr"]]

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -124,9 +124,6 @@ pub use leptos_server::*;
 
 pub use leptos_reactive::debug_warn;
 
-#[cfg(not(any(feature = "csr", feature = "ssr", feature = "hydrate")))]
-compile_error!("set one of the following feature flags: 'csr', 'ssr' or 'hydrate'");
-
 #[cfg(all(feature = "csr", feature = "ssr"))]
 compile_error!("leptos features 'csr' and feature 'ssr' cannot be enabled at the same time");
 

--- a/leptos_core/Cargo.toml
+++ b/leptos_core/Cargo.toml
@@ -15,6 +15,14 @@ log = "0.4"
 
 [features]
 csr = ["leptos_dom/csr", "leptos_macro/csr", "leptos_reactive/csr"]
-hydrate = ["leptos_dom/hydrate", "leptos_macro/hydrate", "leptos_reactive/hydrate"]
+hydrate = [
+  "leptos_dom/hydrate",
+  "leptos_macro/hydrate",
+  "leptos_reactive/hydrate",
+]
 ssr = ["leptos_dom/ssr", "leptos_macro/ssr", "leptos_reactive/ssr"]
 stable = ["leptos_dom/stable", "leptos_macro/stable", "leptos_reactive/stable"]
+
+[package.metadata.cargo-all-features]
+# mutually exclusive features
+skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["hydrate", "ssr"]]

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -51,11 +51,23 @@ features = [
   "Storage",
   "Text",
   "TreeWalker",
-  "Window"
+  "Window",
 ]
 
 [features]
 csr = ["leptos_reactive/csr"]
 hydrate = ["leptos_reactive/hydrate"]
-ssr = ["leptos_reactive/ssr", "dep:futures", "dep:html-escape", "dep:serde_json"]
+ssr = [
+  "leptos_reactive/ssr",
+  "dep:futures",
+  "dep:html-escape",
+  "dep:serde_json",
+]
 stable = ["leptos_reactive/stable"]
+
+[package.metadata.cargo-all-features]
+# mutually exclusive features
+skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["hydrate", "ssr"]]
+
+# No need to test optional dependencies as they are enabled by the ssr feature
+denylist = ["futures", "html-escape", "serde_json"]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -30,3 +30,7 @@ csr = ["leptos_dom/csr", "leptos_reactive/csr"]
 hydrate = ["leptos_dom/hydrate", "leptos_reactive/hydrate"]
 ssr = ["leptos_dom/ssr", "leptos_reactive/ssr"]
 stable = ["leptos_dom/stable", "leptos_reactive/stable"]
+
+[package.metadata.cargo-all-features]
+# mutually exclusive features
+skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["hydrate", "ssr"]]

--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -44,3 +44,7 @@ stable = []
 serde = ["dep:serde"]
 serde-lite = ["dep:serde-lite"]
 miniserde = ["dep:miniserde"]
+
+[package.metadata.cargo-all-features]
+# mutually exclusive features
+skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["hydrate", "ssr"]]

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -19,3 +19,7 @@ csr = ["leptos_dom/csr", "leptos_reactive/csr", "dep:gloo-net"]
 hydrate = ["leptos_dom/hydrate", "leptos_reactive/hydrate", "dep:gloo-net"]
 ssr = ["leptos_dom/ssr", "leptos_reactive/ssr"]
 stable = ["leptos_dom/stable", "leptos_reactive/stable"]
+
+[package.metadata.cargo-all-features]
+# mutually exclusive features
+skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["hydrate", "ssr"]]

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -13,13 +13,14 @@ log = "0.4"
 
 [dependencies.web-sys]
 version = "0.3"
-features = [
-	"HtmlLinkElement",
-	"HtmlTitleElement"
-]
+features = ["HtmlLinkElement", "HtmlTitleElement"]
 
 [features]
 default = ["csr"]
 csr = ["leptos/csr"]
 hydrate = ["leptos/hydrate"]
 ssr = ["leptos/ssr"]
+
+[package.metadata.cargo-all-features]
+# mutually exclusive features
+skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["hydrate", "ssr"]]

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -60,3 +60,7 @@ hydrate = [
 	"dep:wasm-bindgen-futures",
 ]
 ssr = ["leptos/ssr", "dep:url", "dep:regex"]
+
+[package.metadata.cargo-all-features]
+# mutually exclusive features
+skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["hydrate", "ssr"]]


### PR DESCRIPTION
Excluded examples and created a Makefile. 

Install cargo-make with:
> cargo install --force cargo-make

Build, from workspace root with:
> cargo make build

Test:
> cargo make test

Note that the Makefile should be ok, but the build of leptos_reactive with `hydrate` currently fails.