### PR TITLE
Allow on-, class-, prop-, and attr- as equivalent to on:, class:, pro…

### DIFF
--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -81,3 +81,33 @@ fn test_classes() {
         );
     });
 }
+
+#[cfg(not(any(feature = "csr", feature = "hydrate")))]
+#[test]
+fn test_dash_prefixes() {
+    use leptos_dom::*;
+    use leptos_macro::view;
+    use leptos_reactive::{create_signal, run_scope};
+
+    let colons = run_scope(|cx| {
+        let (value, set_value) = create_signal(cx, 5);
+        view! {
+            cx,
+            <div class="my big" class:a={move || value() > 10} class:red=true class:car={move || value() > 1} attr:id="id"></div>
+        }
+    });
+
+    let dashes = run_scope(|cx| {
+        let (value, set_value) = create_signal(cx, 5);
+        view! {
+            cx,
+            <div class="my big" class-a={move || value() > 10} class-red=true class-car={move || value() > 1} attr-id="id"></div>
+        }
+    });
+
+    assert_eq!(colons, dashes);
+    assert_eq!(
+        dashes,
+        "<div data-hk=\"0-0\" class=\"my big  red car\" id=\"id\"></div>"
+    );
+}

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -105,7 +105,7 @@ mod server;
 /// # });
 /// ```
 ///
-/// 5. Event handlers can be added with `on:` attributes
+/// 5. Event handlers can be added with `on:` attributes. If the event name contains a dash, you should use `on-` as the prefix instead.
 /// ```rust
 /// # use leptos_reactive::*; use leptos_dom::*; use leptos_macro::view; use leptos_dom::wasm_bindgen::JsCast;
 /// # run_scope(|cx| {
@@ -124,7 +124,7 @@ mod server;
 /// ```
 ///
 /// 6. DOM properties can be set with `prop:` attributes, which take any primitive type or `JsValue` (or a signal
-///    that returns a primitive or JsValue).
+///    that returns a primitive or JsValue). If your property name contains a dash, you should use `prop-` as the prefix instead.
 /// ```rust
 /// # use leptos_reactive::*; use leptos_dom::*; use leptos_macro::view; use leptos_dom::wasm_bindgen::JsCast;
 /// # run_scope(|cx| {
@@ -147,6 +147,7 @@ mod server;
 /// ```
 ///
 /// 7. Classes can be toggled with `class:` attributes, which take a `bool` (or a signal that returns a `bool`).
+///    If your class name contains a dash, you should use `class-` as the prefix instead.
 /// ```rust
 /// # use leptos_reactive::*; use leptos_dom::*; use leptos_macro::view; use leptos_dom::wasm_bindgen::JsCast;
 /// # run_scope(|cx| {


### PR DESCRIPTION
…p:, and attr: to get around a syn-rsx parsing limitation on mixing colons and dashes in an attribute name