### PR TITLE
Fix `focus`, `blur`, and other non-bubbling events

### DIFF
--- a/leptos_dom/src/operations.rs
+++ b/leptos_dom/src/operations.rs
@@ -238,6 +238,15 @@ pub fn add_event_listener(
     event_delegation::add_event_listener(event_name);
 }
 
+pub fn add_event_listener_undelegated(
+    target: &web_sys::Element,
+    event_name: &'static str,
+    cb: impl FnMut(web_sys::Event) + 'static,
+) {
+    let cb = Closure::wrap(Box::new(cb) as Box<dyn FnMut(web_sys::Event)>).into_js_value();
+    _ = target.add_event_listener_with_callback(event_name, cb.unchecked_ref());
+}
+
 #[inline(always)]
 pub fn ssr_event_listener(_cb: impl FnMut(web_sys::Event) + 'static) {
     // this function exists only for type inference in templates for SSR

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -23,6 +23,7 @@ leptos_reactive = { path = "../leptos_reactive", version = "0.0.12" }
 [dev-dependencies]
 log = "0.4"
 typed-builder = "0.10"
+leptos = { path = "../leptos", version = "0.0.15" }
 
 [features]
 default = ["ssr"]


### PR DESCRIPTION
Avoid manual delegation for all the DOM events that don't bubble by default. (This is technically too conservative, as one or two of these only don't bubble on certain elements, but it's simpler than passing in the element name and only a very small deopt in those cases.)