### PR TITLE
Fix the out-of-order component/element rendering in #53.

### DIFF
--- a/leptos_dom/src/operations.rs
+++ b/leptos_dom/src/operations.rs
@@ -75,17 +75,13 @@ pub fn insert_before(
         debug_warn!("insert_before: trying to insert on a parent node that is not an element");
         new.clone()
     } else if let Some(existing) = existing {
-        if existing.parent_node().as_ref() == Some(parent.unchecked_ref()) {
-            match parent.insert_before(new, Some(existing)) {
-                Ok(c) => c,
-                Err(e) => {
-                    debug_warn!("{:?}", e.as_string());
-                    new.clone()
-                }
+        let parent = existing.parent_node().unwrap_throw();
+        match parent.insert_before(new, Some(existing)) {
+            Ok(c) => c,
+            Err(e) => {
+                debug_warn!("{:?}", e.as_string());
+                new.clone()
             }
-        } else {
-            debug_warn!("insert_before: existing node is not a child of parent node");
-            parent.append_child(new).unwrap_throw()
         }
     } else {
         parent.append_child(new).unwrap_throw()

--- a/leptos_dom/src/render.rs
+++ b/leptos_dom/src/render.rs
@@ -233,11 +233,7 @@ pub fn insert_expression(
                 }
                 Child::Null => match before {
                     Marker::BeforeChild(before) => {
-                        if before.is_connected() {
-                            Child::Node(insert_before(&parent, node, Some(before)))
-                        } else {
-                            Child::Node(append_child(&parent, node))
-                        }
+                        Child::Node(insert_before(&parent, node, Some(before)))
                     }
                     _ => Child::Node(append_child(&parent, node)),
                 },

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -276,21 +276,21 @@ fn element_to_tokens(
             quote_spanned! {
                 span => let #this_el_ident = #debug_name;
                     let #this_el_ident = #parent.clone().unchecked_into::<web_sys::Node>();
-                    log::debug!("=> got {}", #this_el_ident.node_name());
+                    //debug!("=> got {}", #this_el_ident.node_name());
             }
         } else if let Some(prev_sib) = &prev_sib {
             quote_spanned! {
                 span => let #this_el_ident = #debug_name;
-                    log::debug!("next_sibling ({})", #debug_name);
+                    //log::debug!("next_sibling ({})", #debug_name);
                     let #this_el_ident = #prev_sib.next_sibling().unwrap_throw();
-                    log::debug!("=> got {}", #this_el_ident.node_name());
+                    //log::debug!("=> got {}", #this_el_ident.node_name());
             }
         } else {
             quote_spanned! {
                 span => let #this_el_ident = #debug_name;
-                    log::debug!("first_child ({})", #debug_name);
+                    //log::debug!("first_child ({})", #debug_name);
                     let #this_el_ident = #parent.first_child().unwrap_throw();
-                    log::debug!("=> got {}", #this_el_ident.node_name());
+                    //log::debug!("=> got {}", #this_el_ident.node_name());
             }
         };
         navigations.push(this_nav);
@@ -809,15 +809,15 @@ fn component_to_tokens(
 
             let starts_at = if let Some(prev_sib) = prev_sib {
                 quote::quote! {{
-                    log::debug!("starts_at = next_sibling");
+                    //log::debug!("starts_at = next_sibling");
                     #prev_sib.next_sibling().unwrap_throw()
-                    log::debug!("ok starts_at");
+                    //log::debug!("ok starts_at");
                 }}
             } else {
                 quote::quote! {{
-                    log::debug!("starts_at first_child");
+                    //log::debug!("starts_at first_child");
                     #parent.first_child().unwrap_throw()
-                    log::debug!("starts_at ok");
+                    //log::debug!("starts_at ok");
                 }}
             };
 


### PR DESCRIPTION
I think I've nailed this one down, mostly by removing old rendering code that was doing a wrong-headed kind of check that had failed to fix an early bug (oops) and by restoring something in the view macro that I'd been reasoning about a little incorrectly.

I definitely want to manually test the various examples to see if this causes issues, in addition to letting the CI run.