### PR TITLE
Make `render_to_stream()` return a `Stream` that is `Send`

### DIFF
--- a/leptos_dom/src/render_to_string.rs
+++ b/leptos_dom/src/render_to_string.rs
@@ -16,7 +16,7 @@ cfg_if! {
         use leptos_reactive::*;
 
         use crate::Element;
-        use futures::{stream::FuturesUnordered, Stream, StreamExt};
+        use futures::{stream::FuturesUnordered, SinkExt, Stream, StreamExt};
 
         /// Renders a component to a stream of HTML strings.
         ///
@@ -30,8 +30,8 @@ cfg_if! {
         ///    it is waiting for a resource to resolve from the server, it doesn't run it initially.
         /// 3) HTML fragments to replace each `<Suspense/>` fallback with its actual data as the resources
         ///    read under that `<Suspense/>` resolve.
-        pub fn render_to_stream(view: impl Fn(Scope) -> Element + 'static) -> impl Stream<Item = String> {
-            let ((shell, pending_resources, pending_fragments, serializers), _, disposer) =
+        pub fn render_to_stream(view: impl Fn(Scope) -> Element + 'static) -> impl Stream<Item = String> + Send {
+            let ((shell, pending_resources, pending_fragments, mut serializers), _, disposer) =
                 run_scope_undisposed({
                     move |cx| {
                         // the actual app body/template code
@@ -50,14 +50,16 @@ cfg_if! {
                     }
                 });
 
-            let fragments = FuturesUnordered::new();
+            let mut fragments = FuturesUnordered::new();
             for (fragment_id, fut) in pending_fragments {
                 fragments.push(async move { (fragment_id, fut.await) })
             }
 
-            // HTML for the view function and script to store resources
-            futures::stream::once(async move {
-                format!(
+            let (mut tx, rx) = futures::channel::mpsc::channel(8);
+
+            spawn_local(async move {
+                // HTML for the view function and script to store resources
+                tx.send(format!(
                     r#"
                         {shell}
                         <script>
@@ -66,46 +68,46 @@ cfg_if! {
                             __LEPTOS_RESOURCE_RESOLVERS = new Map();
                         </script>
                     "#
-                )
-            })
+                )).await;
 
-            // TODO this is wrong: it should merge the next two streams, not chain them
-            // you may well need to resolve some fragments before some of the resources are resolved
+                // TODO this is wrong: it should merge the next two streams, not chain them
+                // you may well need to resolve some fragments before some of the resources are resolved
 
-            // stream data for each Resource as it resolves
-            .chain(serializers.map(|(id, json)| {
-                let id = serde_json::to_string(&id).unwrap();
-                format!(
-                    r#"<script>
-                            if(__LEPTOS_RESOURCE_RESOLVERS.get({id})) {{
-                                console.log("(create_resource) calling resolver");
-                                __LEPTOS_RESOURCE_RESOLVERS.get({id})({json:?})
-                            }} else {{
-                                console.log("(create_resource) saving data for resource creation");
-                                __LEPTOS_RESOLVED_RESOURCES.set({id}, {json:?});
-                            }}
-                        </script>"#,
-                )
-            }))
-            // stream HTML for each <Suspense/> as it resolves
-            .chain(fragments.map(|(fragment_id, html)| {
-                format!(
-                    r#"
-                        <template id="{fragment_id}">{html}</template>
-                        <script>
-                            var frag = document.querySelector(`[data-fragment-id="{fragment_id}"]`);
-                            var tpl = document.getElementById("{fragment_id}");
-                            console.log("replace", frag, "with", tpl.content.cloneNode(true));
-                            frag.replaceWith(tpl.content.cloneNode(true));
-                        </script>
+                // stream data for each Resource as it resolves
+                while let Some((id, json)) = serializers.next().await {
+                    let id = serde_json::to_string(&id).unwrap();
+                    tx.send(format!(
+                        r#"<script>
+                                if(__LEPTOS_RESOURCE_RESOLVERS.get({id})) {{
+                                    console.log("(create_resource) calling resolver");
+                                    __LEPTOS_RESOURCE_RESOLVERS.get({id})({json:?})
+                                }} else {{
+                                    console.log("(create_resource) saving data for resource creation");
+                                    __LEPTOS_RESOLVED_RESOURCES.set({id}, {json:?});
+                                }}
+                            </script>"#,
+                    )).await;
+                }
+
+                // stream HTML for each <Suspense/> as it resolves
+                while let Some((fragment_id, html)) = fragments.next().await {
+                    tx.send(format!(
+                        r#"
+                            <template id="{fragment_id}">{html}</template>
+                            <script>
+                                var frag = document.querySelector(`[data-fragment-id="{fragment_id}"]`);
+                                var tpl = document.getElementById("{fragment_id}");
+                                console.log("replace", frag, "with", tpl.content.cloneNode(true));
+                                frag.replaceWith(tpl.content.cloneNode(true));
+                            </script>
                         "#
-                )
-            }))
-            // dispose of Scope
-            .chain(futures::stream::once(async {
+                    )).await;
+                }
+
                 disposer.dispose();
-                Default::default()
-            }))
+            });
+
+            rx
         }
     }
 }


### PR DESCRIPTION
Also fixes the order of resource and `<Suspense/>` fragment streaming so that suspense fragments that resolve while some resources are still pending can send their HTML.