### PR TITLE
Allow triggering an effect to re-run from within the effect

### DIFF
--- a/docs/COMMON_BUGS.md
+++ b/docs/COMMON_BUGS.md
@@ -4,35 +4,6 @@ This document is intended as a running list of common issues, with example code 
 
 ## Reactivity
 
-### Don't get and set a signal within the same effect
-
-**Issue**: Sometimes you need access to a signal's current value when setting a new value.
-
-```rust,should_panic
-let (a, set_a) = create_signal(cx, false);
-
-create_effect(cx, move |_| {
-	if !a() {
-		set_a(true); // ❌ panics: already borrowed
-	}
-});
-```
-
-**Solution**: Use the `.update()` function instead.
-
-```rust
-let (a, set_a) = create_signal(cx, false);
-
-create_effect(cx, move |_| {
-	// ✅ updates the signal, which provides you with the current value
-	set_a.update(|a: &mut bool| {
-		if *a {
-			*a = false;
-		}
-	})
-});
-```
-
 ### Avoid writing to a signal from an effect
 
 **Issue**: Sometimes you want to update a reactive signal in a way that depends on another signal.

--- a/examples/view-tests/src/main.rs
+++ b/examples/view-tests/src/main.rs
@@ -3,9 +3,25 @@ use leptos::*;
 pub fn main() {
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
-    mount_to_body(|cx| view! { cx, <Tests/> })
+    mount_to_body(|cx| view! { cx, <Panics/> })
 }
 
+#[component]
+fn Panics(cx: Scope) -> Element {
+    let (a, set_a) = create_signal(cx, false);
+
+    create_effect(cx, move |_| {
+        if !a() {
+            set_a(true);
+        }
+    });
+
+    view! { cx,
+      <h1>"Hello " {move || a().to_string()}</h1>
+    }
+}
+
+/*
 #[component]
 fn Tests(cx: Scope) -> Element {
     view! {
@@ -113,3 +129,4 @@ fn TemplateExample(cx: Scope) -> Element {
         </template>
     }
 }
+ */

--- a/leptos_reactive/src/memo.rs
+++ b/leptos_reactive/src/memo.rs
@@ -54,7 +54,7 @@ use std::fmt::Debug;
 /// });
 /// # }).dispose();
 /// ```
-pub fn create_memo<T>(cx: Scope, f: impl FnMut(Option<&T>) -> T + 'static) -> Memo<T>
+pub fn create_memo<T>(cx: Scope, f: impl Fn(Option<&T>) -> T + 'static) -> Memo<T>
 where
     T: PartialEq + Debug + 'static,
 {

--- a/leptos_reactive/src/scope.rs
+++ b/leptos_reactive/src/scope.rs
@@ -411,12 +411,12 @@ impl Scope {
         use futures::StreamExt;
 
         if let Some(ref mut shared_context) = *self.runtime.shared_context.borrow_mut() {
-            let (mut tx, mut rx) = futures::channel::mpsc::channel::<()>(1);
+            let (tx, mut rx) = futures::channel::mpsc::unbounded();
 
             create_isomorphic_effect(*self, move |_| {
                 let pending = context.pending_resources.try_with(|n| *n).unwrap_or(0);
                 if pending == 0 {
-                    _ = tx.try_send(());
+                    _ = tx.unbounded_send(());
                 }
             });
 

--- a/leptos_reactive/src/signal.rs
+++ b/leptos_reactive/src/signal.rs
@@ -732,7 +732,7 @@ impl SignalId {
                         effects.get(sub).cloned()
                     };
                     if let Some(effect) = effect {
-                        effect.borrow_mut().run(sub, runtime);
+                        //effect.borrow_mut().run(sub, runtime);
                     }
                 }
             }


### PR DESCRIPTION
So that e.g., you can `get()` and `set()` the same signal within the effect — see issue #83