### PR TITLE
Allow accessing `Scope` from server functions

### DIFF
--- a/examples/counter-isomorphic/src/main.rs
+++ b/examples/counter-isomorphic/src/main.rs
@@ -55,7 +55,8 @@ cfg_if! {
 
             if let Some(server_fn) = server_fn_by_path(path.as_str()) {
                 let body: &[u8] = &body;
-                match server_fn(&body).await {
+                let (cx, disposer) = raw_scope_and_disposer();
+                match server_fn(cx, &body).await {
                     Ok(serialized) => {
                         // if this is Accept: application/json then send a serialized JSON response
                         if let Some("application/json") = accept_header {

--- a/examples/todo-app-sqlite/src/todo.rs
+++ b/examples/todo-app-sqlite/src/todo.rs
@@ -34,7 +34,12 @@ cfg_if! {
 }
 
 #[server(GetTodos, "/api")]
-pub async fn get_todos() -> Result<Vec<Todo>, ServerFnError> {
+pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
+    // this is just an example of how to access server context injected in the handlers
+    let req =
+        use_context::<actix_web::HttpRequest>(cx).expect("couldn't get HttpRequest from context");
+    println!("req.path = {:?}", req.path());
+
     use futures::TryStreamExt;
 
     let mut conn = db().await?;
@@ -114,7 +119,11 @@ pub fn Todos(cx: Scope) -> Element {
     let todo_deleted = delete_todo.version;
 
     // list of todos is loaded from the server in reaction to changes
-    let todos = create_resource(cx, move || (add_changed(), todo_deleted()), |_| get_todos());
+    let todos = create_resource(
+        cx,
+        move || (add_changed(), todo_deleted()),
+        move |_| get_todos(cx),
+    );
 
     view! {
         cx,

--- a/leptos_macro/src/server.rs
+++ b/leptos_macro/src/server.rs
@@ -136,14 +136,14 @@ pub fn server_macro_impl(args: proc_macro::TokenStream, s: TokenStream2) -> Resu
             }
 
             #[cfg(feature = "ssr")]
-            fn call_fn(self, cx: Scope) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self::Output, ::leptos::ServerFnError>>>> {
+            fn call_fn(self, cx: ::leptos::Scope) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self::Output, ::leptos::ServerFnError>>>> {
                 let #struct_name { #(#field_names),* } = self;
                 #cx_assign_statement;
                 Box::pin(async move { #fn_name( #cx_fn_arg #(#field_names_2),*).await })
             }
 
             #[cfg(not(feature = "ssr"))]
-            fn call_fn_client(self, cx: Scope) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self::Output, ::leptos::ServerFnError>>>> {
+            fn call_fn_client(self, cx: ::leptos::Scope) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self::Output, ::leptos::ServerFnError>>>> {
                 let #struct_name { #(#field_names_3),* } = self;
                 Box::pin(async move { #fn_name( #cx_fn_arg #(#field_names_4),*).await })
             }

--- a/leptos_macro/src/server.rs
+++ b/leptos_macro/src/server.rs
@@ -7,6 +7,21 @@ use syn::{
     *,
 };
 
+fn fn_arg_is_cx(f: &syn::FnArg) -> bool {
+    if let FnArg::Typed(t) = f {
+        if let Type::Path(path) = &*t.ty {
+            path.path
+                .segments
+                .iter()
+                .any(|segment| segment.ident == "Scope")
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}
+
 pub fn server_macro_impl(args: proc_macro::TokenStream, s: TokenStream2) -> Result<TokenStream2> {
     let ServerFnName {
         struct_name,
@@ -31,13 +46,35 @@ pub fn server_macro_impl(args: proc_macro::TokenStream, s: TokenStream2) -> Resu
         }
     }
 
-    let fields = body.inputs.iter().map(|f| {
+    let fields = body.inputs.iter().filter(|f| !fn_arg_is_cx(f)).map(|f| {
         let typed_arg = match f {
             FnArg::Receiver(_) => panic!("cannot use receiver types in server function macro"),
             FnArg::Typed(t) => t,
         };
         quote! { pub #typed_arg }
     });
+
+    let cx_arg = body
+        .inputs
+        .iter()
+        .next()
+        .and_then(|f| if fn_arg_is_cx(f) { Some(f) } else { None });
+    let cx_assign_statement = if let Some(FnArg::Typed(arg)) = cx_arg {
+        if let Pat::Ident(id) = &*arg.pat {
+            quote! {
+                let #id = cx;
+            }
+        } else {
+            quote! {}
+        }
+    } else {
+        quote! {}
+    };
+    let cx_fn_arg = if cx_arg.is_some() {
+        quote! { cx, }
+    } else {
+        quote! {}
+    };
 
     let fn_args = body.inputs.iter().map(|f| {
         let typed_arg = match f {
@@ -50,7 +87,13 @@ pub fn server_macro_impl(args: proc_macro::TokenStream, s: TokenStream2) -> Resu
 
     let field_names = body.inputs.iter().filter_map(|f| match f {
         FnArg::Receiver(_) => todo!(),
-        FnArg::Typed(t) => Some(&t.pat),
+        FnArg::Typed(t) => {
+            if fn_arg_is_cx(f) {
+                None
+            } else {
+                Some(&t.pat)
+            }
+        }
     });
 
     let field_names_2 = field_names.clone();
@@ -93,15 +136,16 @@ pub fn server_macro_impl(args: proc_macro::TokenStream, s: TokenStream2) -> Resu
             }
 
             #[cfg(feature = "ssr")]
-            fn call_fn(self) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self::Output, ::leptos::ServerFnError>> + Send>> {
+            fn call_fn(self, cx: Scope) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self::Output, ::leptos::ServerFnError>>>> {
                 let #struct_name { #(#field_names),* } = self;
-                Box::pin(async move { #fn_name( #(#field_names_2),*).await })
+                #cx_assign_statement;
+                Box::pin(async move { #fn_name( #cx_fn_arg #(#field_names_2),*).await })
             }
 
             #[cfg(not(feature = "ssr"))]
-            fn call_fn_client(self) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self::Output, ::leptos::ServerFnError>>>> {
+            fn call_fn_client(self, cx: Scope) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self::Output, ::leptos::ServerFnError>>>> {
                 let #struct_name { #(#field_names_3),* } = self;
-                Box::pin(async move { #fn_name( #(#field_names_4),*).await })
+                Box::pin(async move { #fn_name( #cx_fn_arg #(#field_names_4),*).await })
             }
         }
 

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -57,6 +57,13 @@ impl Runtime {
         Self::default()
     }
 
+    pub fn raw_scope_and_disposer(&'static self) -> (Scope, ScopeDisposer) {
+        let id = { self.scopes.borrow_mut().insert(Default::default()) };
+        let scope = Scope { runtime: self, id };
+        let disposer = ScopeDisposer(Box::new(move || scope.dispose()));
+        (scope, disposer)
+    }
+
     pub fn run_scope_undisposed<T>(
         &'static self,
         f: impl FnOnce(Scope) -> T,

--- a/leptos_reactive/src/scope.rs
+++ b/leptos_reactive/src/scope.rs
@@ -13,8 +13,20 @@ use std::{future::Future, pin::Pin};
 /// This should usually only be used once, at the root of an application, because its reactive
 /// values will not have access to values created under another `create_scope`.
 pub fn create_scope(f: impl FnOnce(Scope) + 'static) -> ScopeDisposer {
+    // TODO leak
     let runtime = Box::leak(Box::new(Runtime::new()));
     runtime.run_scope_undisposed(f, None).2
+}
+
+#[must_use = "Scope will leak memory if the disposer function is never called"]
+/// Creates a new reactive system and root reactive scope, and returns them.
+///
+/// This should usually only be used once, at the root of an application, because its reactive
+/// values will not have access to values created under another `create_scope`.
+pub fn raw_scope_and_disposer() -> (Scope, ScopeDisposer) {
+    // TODO leak
+    let runtime = Box::leak(Box::new(Runtime::new()));
+    runtime.raw_scope_and_disposer()
 }
 
 /// Creates a temporary scope, runs the given function, disposes of the scope,

--- a/leptos_server/src/action.rs
+++ b/leptos_server/src/action.rs
@@ -264,8 +264,8 @@ where
     S: Clone + ServerFn,
 {
     #[cfg(feature = "ssr")]
-    let c = |args: &S| S::call_fn(args.clone());
+    let c = move |args: &S| S::call_fn(args.clone(), cx);
     #[cfg(not(feature = "ssr"))]
-    let c = |args: &S| S::call_fn_client(args.clone());
+    let c = move |args: &S| S::call_fn_client(args.clone(), cx);
     create_action(cx, c).using_server_fn::<S>()
 }

--- a/leptos_server/src/multi_action.rs
+++ b/leptos_server/src/multi_action.rs
@@ -274,8 +274,8 @@ where
     S: Clone + ServerFn,
 {
     #[cfg(feature = "ssr")]
-    let c = |args: &S| S::call_fn(args.clone());
+    let c = move |args: &S| S::call_fn(args.clone(), cx);
     #[cfg(not(feature = "ssr"))]
-    let c = |args: &S| S::call_fn_client(args.clone());
+    let c = move |args: &S| S::call_fn_client(args.clone(), cx);
     create_multi_action(cx, c).using_server_fn::<S>()
 }


### PR DESCRIPTION
This can be used to inject server-only dependencies like `HttpRequest` and `HttpResponse`. and access them from the server function.

This allows you to do things like access and set cookies in a way that doesn't couple Leptos to any particular server framework or its types.