### PR TITLE
Add typed event handlers

### DIFF
--- a/examples/parent-child/src/lib.rs
+++ b/examples/parent-child/src/lib.rs
@@ -1,5 +1,5 @@
 use leptos::*;
-use web_sys::Event;
+use web_sys::MouseEvent;
 
 // This highlights four different ways that child components can communicate
 // with their parent:
@@ -71,7 +71,7 @@ pub fn ButtonA(cx: Scope, setter: WriteSignal<bool>) -> Element {
 #[component]
 pub fn ButtonB<F>(cx: Scope, on_click: F) -> Element
 where
-    F: Fn(Event) + 'static,
+    F: Fn(MouseEvent) + 'static,
 {
     view! {
         cx,
@@ -82,11 +82,11 @@ where
         </button>
     }
 
-    // just a note: in an ordinary function ButtonB could take on_click: impl Fn(Event) + 'static
+    // just a note: in an ordinary function ButtonB could take on_click: impl Fn(MouseEvent) + 'static
     // and save you from typing out the generic
     // the component macro actually expands to define a
     //
-    // struct ButtonBProps<F> where F: Fn(Event) + 'static {
+    // struct ButtonBProps<F> where F: Fn(MouseEvent) + 'static {
     //   on_click: F
     // }
     //

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -136,10 +136,10 @@ pub fn TodoMVC(cx: Scope) -> Element {
     });
 
     // Callback to add a todo on pressing the `Enter` key, if the field isn't empty
-    let add_todo = move |ev: web_sys::Event| {
+    let add_todo = move |ev: web_sys::KeyboardEvent| {
         let target = event_target::<HtmlInputElement>(&ev);
         ev.stop_propagation();
-        let key_code = ev.unchecked_ref::<web_sys::KeyboardEvent>().key_code();
+        let key_code = ev.key_code();
         if key_code == ENTER_KEY {
             let title = event_target_value(&ev);
             let title = title.trim();
@@ -311,7 +311,7 @@ pub fn Todo(cx: Scope, todo: Todo) -> Element {
                     prop:value={move || todo.title.get()}
                     on:focusout=move |ev| save(&event_target_value(&ev))
                     on:keyup={move |ev| {
-                        let key_code = ev.unchecked_ref::<web_sys::KeyboardEvent>().key_code();
+                        let key_code = ev.key_code();
                         if key_code == ENTER_KEY {
                             save(&event_target_value(&ev));
                         } else if key_code == ESCAPE_KEY {

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -53,6 +53,20 @@ features = [
   "Text",
   "TreeWalker",
   "Window",
+
+  # Events we cast to in leptos_macro -- added here so we don't force users to import them
+  "MouseEvent",
+  "DragEvent",
+  "FocusEvent",
+  "KeyboardEvent",
+  "ProgressEvent",
+  "WheelEvent",
+  "InputEvent",
+  "SubmitEvent",
+  "AnimationEvent",
+  "PointerEvent",
+  "TouchEvent",
+  "TransitionEvent"
 ]
 
 [dev-dependencies]

--- a/leptos_dom/src/operations.rs
+++ b/leptos_dom/src/operations.rs
@@ -269,18 +269,23 @@ pub fn add_event_listener<E>(
 }
 
 #[doc(hidden)]
-pub fn add_event_listener_undelegated(
+pub fn add_event_listener_undelegated<E>(
     target: &web_sys::Element,
     event_name: &'static str,
-    cb: impl FnMut(web_sys::Event) + 'static,
-) {
-    let cb = Closure::wrap(Box::new(cb) as Box<dyn FnMut(web_sys::Event)>).into_js_value();
+    cb: impl FnMut(E) + 'static,
+) where
+    E: FromWasmAbi + 'static,
+{
+    let cb = Closure::wrap(Box::new(cb) as Box<dyn FnMut(E)>).into_js_value();
     _ = target.add_event_listener_with_callback(event_name, cb.unchecked_ref());
 }
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn ssr_event_listener(_cb: impl FnMut(web_sys::Event) + 'static) {
+pub fn ssr_event_listener<E>(_cb: impl FnMut(E) + 'static)
+where
+    E: FromWasmAbi + 'static,
+{
     // this function exists only for type inference in templates for SSR
 }
 

--- a/leptos_dom/src/operations.rs
+++ b/leptos_dom/src/operations.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use wasm_bindgen::{prelude::Closure, JsCast, JsValue, UnwrapThrowExt};
+use wasm_bindgen::convert::FromWasmAbi;
 
 use crate::{debug_warn, event_delegation, is_server};
 
@@ -250,12 +251,12 @@ pub fn set_interval(
 }
 
 /// Adds an event listener to the target DOM element using implicit event delegation.
-pub fn add_event_listener(
+pub fn add_event_listener<E>(
     target: &web_sys::Element,
     event_name: &'static str,
-    cb: impl FnMut(web_sys::Event) + 'static,
-) {
-    let cb = Closure::wrap(Box::new(cb) as Box<dyn FnMut(web_sys::Event)>).into_js_value();
+    cb: impl FnMut(E) + 'static,
+) where E: FromWasmAbi + 'static {
+    let cb = Closure::wrap(Box::new(cb) as Box<dyn FnMut(E)>).into_js_value();
     let key = event_delegation::event_delegation_key(event_name);
     _ = js_sys::Reflect::set(target, &JsValue::from_str(&key), &cb);
     event_delegation::add_event_listener(event_name);

--- a/leptos_dom/src/render_to_string.rs
+++ b/leptos_dom/src/render_to_string.rs
@@ -12,7 +12,7 @@ pub fn escape_attr(text: &str) -> Cow<'_, str> {
 }
 
 cfg_if! {
-    if #[cfg(any(doc, feature = "ssr"))] {
+    if #[cfg(not(any(feature = "csr", feature = "hydrate")))] {
         use leptos_reactive::*;
 
         use crate::Element;

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -18,8 +18,9 @@ quote = "1"
 syn = { version = "1", features = ["full", "parsing", "extra-traits"] }
 syn-rsx = "0.9"
 uuid = { version = "1", features = ["v4"] }
-leptos_dom = { path = "../leptos_dom", version = "0.0.17" }
-leptos_reactive = { path = "../leptos_reactive", version = "0.0.17" }
+leptos_dom = { path = "../leptos_dom", version = "0.0.18" }
+leptos_reactive = { path = "../leptos_reactive", version = "0.0.18" }
+lazy_static = "1.4"
 
 [dev-dependencies]
 log = "0.4"

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -111,14 +111,15 @@ mod server;
 /// # });
 /// ```
 ///
-/// 5. Event handlers can be added with `on:` attributes.
+/// 5. Event handlers can be added with `on:` attributes. In most cases, the events are given the correct type
+///    based on the event name.
 /// ```rust
 /// # use leptos_reactive::*; use leptos_dom::*; use leptos_macro::view; use leptos_dom::wasm_bindgen::JsCast;
 /// # run_scope(create_runtime(), |cx| {
 /// # if !cfg!(any(feature = "csr", feature = "hydrate")) {
 /// view! {
 ///   cx,
-///   <button on:click=|ev: web_sys::Event| {
+///   <button on:click=|ev: web_sys::MouseEvent| {
 ///     log::debug!("click event: {ev:#?}");
 ///   }>
 ///     "Click me"
@@ -203,9 +204,9 @@ mod server;
 ///
 ///     // create event handlers for our buttons
 ///     // note that `value` and `set_value` are `Copy`, so it's super easy to move them into closures
-///     let clear = move |_ev: web_sys::Event| set_value(0);
-///     let decrement = move |_ev: web_sys::Event| set_value.update(|value| *value -= 1);
-///     let increment = move |_ev: web_sys::Event| set_value.update(|value| *value += 1);
+///     let clear = move |_ev: web_sys::MouseEvent| set_value(0);
+///     let decrement = move |_ev: web_sys::MouseEvent| set_value.update(|value| *value -= 1);
+///     let increment = move |_ev: web_sys::MouseEvent| set_value.update(|value| *value += 1);
 ///
 ///     // this JSX is compiled to an HTML template string for performance
 ///     view! {

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -590,11 +590,11 @@ fn attr_to_tokens(
                 });
             } else if let Some(event_type) = EVENTS.get(&name.as_str()).map(|&e| e.parse::<TokenStream>().unwrap_or_default()) {
                 expressions.push(quote_spanned! {
-                    span => ::leptos::add_event_listener::<#event_type>(#el_id.unchecked_ref(), #name, #handler);
+                    span => ::leptos::add_event_listener::<web_sys::#event_type>(#el_id.unchecked_ref(), #name, #handler);
                 });
             } else {
                 expressions.push(quote_spanned! {
-                    span => ::leptos::add_event_listener::<Event>(#el_id.unchecked_ref(), #name, #handler);
+                    span => ::leptos::add_event_listener::<web_sys::Event>(#el_id.unchecked_ref(), #name, #handler);
                 });
             }
         } else {
@@ -1117,7 +1117,7 @@ fn create_component(cx: &Ident, node: &NodeElement, mode: Mode) -> TokenStream {
                 })
             } else {
                 Some(quote_spanned! {
-                    span => ::leptos::add_event_listener::<Event>(#component_name.unchecked_ref(), #event_name, #handler)
+                    span => ::leptos::add_event_listener::<web_sys::Event>(#component_name.unchecked_ref(), #event_name, #handler)
                 })
             }
         }

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -64,7 +64,7 @@ where
     let action_version = version;
     let action = use_resolved_path(cx, move || action.to_href()());
 
-    let on_submit = move |ev: web_sys::Event| {
+    let on_submit = move |ev: web_sys::SubmitEvent| {
         if ev.default_prevented() {
             return;
         }
@@ -262,7 +262,7 @@ where
         ""
     }.to_string();
 
-    let on_submit = move |ev: web_sys::Event| {
+    let on_submit = move |ev: web_sys::SubmitEvent| {
         if ev.default_prevented() {
             return;
         }


### PR DESCRIPTION
Hi, I tried to implement #93. I borrowed the code of event types from Yew.

This works fine for me in my test code:
```rust
use leptos::*;
use web_sys::{Event, MouseEvent, DragEvent};

pub fn simple_counter(cx: Scope) -> web_sys::Element {
    let (value, set_value) = create_signal(cx, 0);

    view! { cx,
        <div>
            <button on:click=move |ev| {set_value(0); warn!("{}", ev.x())}>"Clear"</button>
            <button on:something=move |_| set_value.update(|value| *value -= 1)>"-1"</button>
            <span on:drag=move |ev| {warn!("{}", ev.x())} >"Value: " {move || value().to_string()} "!"</span>
            <button on:click=move |_| set_value.update(|value| *value += 1)>"+1"</button>
        </div>
    }
}
```