### PR TITLE
Fix path deps' going one level too high

### DIFF
--- a/examples/counter-isomorphic/Cargo.toml
+++ b/examples/counter-isomorphic/Cargo.toml
@@ -16,12 +16,12 @@ serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 cfg-if = "1"
 lazy_static = "1"
-leptos = { path = "../../../leptos/leptos", default-features = false, features = [
+leptos = { path = "../../leptos", default-features = false, features = [
 	"serde",
 ] }
-leptos_actix = { path = "../../../leptos/integrations/actix", optional = true }
-leptos_meta = { path = "../../../leptos/meta", default-features = false }
-leptos_router = { path = "../../../leptos/router", default-features = false }
+leptos_actix = { path = "../../integrations/actix", optional = true }
+leptos_meta = { path = "../../meta", default-features = false }
+leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
 simple_logger = "2"
 gloo = { git = "https://github.com/rustwasm/gloo" }

--- a/examples/hackernews-axum/Cargo.toml
+++ b/examples/hackernews-axum/Cargo.toml
@@ -12,12 +12,12 @@ console_log = "0.2"
 console_error_panic_hook = "0.1"
 futures = "0.3"
 cfg-if = "1"
-leptos = { path = "../../../leptos/leptos", default-features = false, features = [
+leptos = { path = "../../leptos", default-features = false, features = [
 	"serde",
 ] }
-leptos_axum = { path = "../../../leptos/integrations/axum", optional = true }
-leptos_meta = { path = "../../../leptos/meta", default-features = false }
-leptos_router = { path = "../../../leptos/router", default-features = false }
+leptos_axum = { path = "../../integrations/axum", optional = true }
+leptos_meta = { path = "../../meta", default-features = false }
+leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
 simple_logger = "2"
 serde = { version = "1", features = ["derive"] }

--- a/examples/hackernews/Cargo.toml
+++ b/examples/hackernews/Cargo.toml
@@ -14,11 +14,11 @@ console_log = "0.2"
 console_error_panic_hook = "0.1"
 futures = "0.3"
 cfg-if = "1"
-leptos = { path = "../../../leptos/leptos", default-features = false, features = [
+leptos = { path = "../../leptos", default-features = false, features = [
 	"serde",
 ] }
-leptos_meta = { path = "../../../leptos/meta", default-features = false }
-leptos_router = { path = "../../../leptos/router", default-features = false }
+leptos_meta = { path = "../../meta", default-features = false }
+leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
 simple_logger = "2"
 serde = { version = "1", features = ["derive"] }

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 console_log = "0.2"
 log = "0.4"
 leptos = { path = "../../leptos" }
-leptos_router = { path = "../../router", features=["csr"] }
+leptos_router = { path = "../../router", features = ["csr"] }
 serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 console_error_panic_hook = "0.1.7"
-leptos_meta = { path = "../../../leptos/meta", default-features = false }
+leptos_meta = { path = "../../meta", default-features = false }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"

--- a/examples/todo-app-cbor/Cargo.toml
+++ b/examples/todo-app-cbor/Cargo.toml
@@ -16,12 +16,12 @@ console_error_panic_hook = "0.1"
 serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 cfg-if = "1"
-leptos = { path = "../../../leptos/leptos", default-features = false, features = [
+leptos = { path = "../../leptos", default-features = false, features = [
 	"serde",
 ] }
-leptos_actix = { path = "../../../leptos/integrations/actix", optional = true }
-leptos_meta = { path = "../../../leptos/meta", default-features = false }
-leptos_router = { path = "../../../leptos/router", default-features = false }
+leptos_actix = { path = "../../integrations/actix", optional = true }
+leptos_meta = { path = "../../meta", default-features = false }
+leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
 simple_logger = "2"
 gloo = { git = "https://github.com/rustwasm/gloo" }

--- a/examples/todo-app-sqlite/Cargo.toml
+++ b/examples/todo-app-sqlite/Cargo.toml
@@ -16,12 +16,12 @@ console_error_panic_hook = "0.1"
 serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 cfg-if = "1"
-leptos = { path = "../../../leptos/leptos", default-features = false, features = [
+leptos = { path = "../../leptos", default-features = false, features = [
 	"serde",
 ] }
-leptos_actix = { path = "../../../leptos/integrations/actix", optional = true }
-leptos_meta = { path = "../../../leptos/meta", default-features = false }
-leptos_router = { path = "../../../leptos/router", default-features = false }
+leptos_actix = { path = "../../integrations/actix", optional = true }
+leptos_meta = { path = "../../meta", default-features = false }
+leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
 simple_logger = "2"
 gloo = { git = "https://github.com/rustwasm/gloo" }


### PR DESCRIPTION
The path dependencies go one step too high, meaning that they include the name of the repo. This won't compile since I named the repo *gbj_leptos*. This PR fixes it.