### PR TITLE
Workspace features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ members = [
 ]
 exclude = ["benchmarks", "examples"]
 
+[workspace.package]
+version = "0.1.0-beta"
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,16 @@ exclude = ["benchmarks", "examples"]
 [workspace.package]
 version = "0.1.0-beta"
 
+[workspace.dependencies]
+leptos = { path = "./leptos", default-features = false, version = "0.1.0-beta" }
+leptos_dom = { path = "./leptos_dom", default-features = false, version = "0.1.0-beta" }
+leptos_macro = { path = "./leptos_macro", default-features = false, version = "0.1.0-beta" }
+leptos_reactive = { path = "./leptos_reactive", default-features = false, version = "0.1.0-beta" }
+leptos_server = { path = "./leptos_server", default-features = false, version = "0.1.0-beta" }
+leptos_config = { path = "./leptos_config", default-features = false, version = "0.1.0-beta" }
+leptos_router = { path = "./router", version = "0.1.0-beta" }
+leptos_meta = { path = "./meta", default-feature = false, version = "0.1.0-beta" }
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_actix"
-version = "0.1.0-beta"
+version.workspace = true
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"
@@ -10,13 +10,7 @@ description = "Actix integrations for the Leptos web framework."
 [dependencies]
 actix-web = "4"
 futures = "0.3"
-leptos = { path = "../../leptos", default-features = false, version = "0.1.0-alpha", features = [
-	"ssr",
-] }
-leptos_meta = { path = "../../meta", default-features = false, version = "0.1.0-alpha", features = [
-	"ssr",
-] }
-leptos_router = { path = "../../router", default-features = false, version = "0.1.0-alpha", features = [
-	"ssr",
-] }
+leptos = { workspace = true, features = ["ssr"] }
+leptos_meta = { workspace = true, features = ["ssr"] }
+leptos_router = { workspace = true, features = ["ssr"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_axum"
-version = "0.1.0-beta"
+version.workspace = true
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"
@@ -8,20 +8,14 @@ repository = "https://github.com/gbj/leptos"
 description = "Axum integrations for the Leptos web framework."
 
 [dependencies]
-axum = {version="0.6", features=["macros"]}
+axum = { version = "0.6", features = ["macros"] }
 derive_builder = "0.12.0"
 futures = "0.3"
 http = "0.2.8"
 hyper = "0.14.23"
 kdl = "4.6.0"
-leptos = { path = "../../leptos", default-features = false, version = "0.1.0-beta", features = [
-	"ssr",
-] }
-leptos_meta = { path = "../../meta", default-features = false, version = "0.1.0-beta", features = [
-	"ssr",
-] }
-leptos_router = { path = "../../router", default-features = false, version = "0.1.0-beta", features = [
-	"ssr",
-] }
-leptos_config = { path = "../../leptos_config", default-features = false, version = "0.1.0-beta" }
+leptos = { workspace = true, features = ["ssr"] }
+leptos_meta = { workspace = true, features = ["ssr"] }
+leptos_router = { workspace = true, features = ["ssr"] }
+leptos_config.workspace = true
 tokio = { version = "1.0", features = ["full"] }

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -10,11 +10,11 @@ readme = "../README.md"
 
 [dependencies]
 cfg-if = "1"
-leptos_config = { path = "../leptos_config", default-features = false, version = "0.1.0-beta" }
-leptos_dom = { path = "../leptos_dom", default-features = false, version = "0.1.0-beta" }
-leptos_macro = { path = "../leptos_macro", default-features = false, version = "0.1.0-beta" }
-leptos_reactive = { path = "../leptos_reactive", default-features = false, version = "0.1.0-beta" }
-leptos_server = { path = "../leptos_server", default-features = false, version = "0.1.0-beta" }
+leptos_dom.workspace = true
+leptos_macro.workspace = true
+leptos_reactive.workspace = true
+leptos_server.workspace = true
+leptos_config.workspace = true
 tracing = "0.1"
 typed-builder = "0.11"
 

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos"
-version = "0.1.0-beta"
+version.workspace = true
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -17,7 +17,7 @@ html-escape = "0.2"
 indexmap = "1.9"
 itertools = "0.10"
 js-sys = "0.3"
-leptos_reactive = { path = "../leptos_reactive", default-features = false, version = "0.1.0-beta" }
+leptos_reactive.workspace = true
 once_cell = "1"
 pad-adapter = "0.1"
 paste = "1"

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_dom"
-version = "0.1.0-beta"
+version.workspace = true
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -22,15 +22,15 @@ quote = "1"
 syn = { version = "1", features = ["full"] }
 syn-rsx = "0.9"
 uuid = { version = "1", features = ["v4"] }
-leptos_dom = { path = "../leptos_dom", version = "0.1.0-beta" }
-leptos_reactive = { path = "../leptos_reactive", version = "0.1.0-beta" }
-leptos_server = { path = "../leptos_server", version = "0.1.0-beta" }
+leptos_dom.workspace = true
+leptos_reactive.workspace = true
+leptos_server.workspace = true
 lazy_static = "1.4"
 
 [dev-dependencies]
 log = "0.4"
 typed-builder = "0.10"
-leptos = { path = "../leptos" }
+leptos.workspace = true
 
 [features]
 default = ["ssr"]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_macro"
-version = "0.1.0-beta"
+version.workspace = true
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"

--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_reactive"
-version = "0.1.0-beta"
+version.workspace = true
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/gbj/leptos"
 description = "RPC for the Leptos web framework."
 
 [dependencies]
-leptos_dom = { path = "../leptos_dom", default-features = false, version = "0.1.0-beta" }
-leptos_reactive = { path = "../leptos_reactive", default-features = false, version = "0.1.0-beta" }
+leptos_dom.workspace = true
+leptos_reactive.workspace = true
 form_urlencoded = "1"
 gloo-net = "0.2"
 lazy_static = "1"
@@ -26,7 +26,7 @@ proc-macro2 = "1.0.47"
 ciborium = "0.2.0"
 
 [dev-dependencies]
-leptos = { path = "../leptos", default-features = false }
+leptos.workspace = true
 
 [features]
 csr = [

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_server"
-version = "0.1.0-beta"
+version.workspace = true
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -9,7 +9,7 @@ description = "Tools to set HTML metadata in the Leptos web framework."
 
 [dependencies]
 cfg-if = "1"
-leptos = { path = "../leptos", version = "0.1.0-beta", default-features = false }
+leptos.workspace = true
 tracing = "0.1"
 typed-builder = "0.11"
 

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/gbj/leptos"
 description = "Router for the Leptos web framework."
 
 [dependencies]
-leptos = { path = "../leptos", version = "0.1.0-beta", default-features = false }
+leptos.workspace = true
 cfg-if = "1"
 common_macros = "0.1"
 gloo-net = "0.2"


### PR DESCRIPTION
Using workspace-level defined version and [dependencies](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspacedependencies-table) in order to make sure that the versions match and for reducing the work needed for creating a release.

The `main` branch doesn't compile, so I have not been able to test it.