### PR TITLE
Add config crate and generate file for cargo-leptos to watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ blob.rs
 Cargo.lock
 **/*.rs.bk
 .DS_Store
+.leptos.kdl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "leptos",
   "leptos_dom",
   "leptos_core",
+  "leptos_config",
   "leptos_macro",
   "leptos_reactive",
   "leptos_server",

--- a/examples/hackernews-axum/src/main.rs
+++ b/examples/hackernews-axum/src/main.rs
@@ -41,7 +41,7 @@ if #[cfg(feature = "ssr")] {
         // `GET /` goes to `root`
         .nest_service("/pkg", pkg_service)
         .nest_service("/static", static_service)
-        .fallback(leptos_axum::render_app_to_stream("leptos_hackernews_axum", |cx| view! { cx, <App/> }));
+        .fallback(leptos_axum::render_app_to_stream("/pkg/leptos_hackernews_axum", |cx| view! { cx, <App/> }));
 
         // run our app with hyper
         // `axum::Server` is a re-export of `hyper::Server`

--- a/examples/hackernews-axum/src/main.rs
+++ b/examples/hackernews-axum/src/main.rs
@@ -12,6 +12,7 @@ if #[cfg(feature = "ssr")] {
     use http::StatusCode;
     use std::net::SocketAddr;
     use tower_http::services::ServeDir;
+    use leptos_axum::RenderOptions;
 
     #[tokio::main]
     async fn main() {
@@ -36,12 +37,14 @@ if #[cfg(feature = "ssr")] {
             )
         }
 
+        let render_options: RenderOptions = leptos_axum::RenderOptionsBuilder::default().client_pkg_path("/pkg/leptos_hackernews_axum").auto_reload(3001).build().expect("Failed to Parse RenderOptions");
+
         // build our application with a route
         let app = Router::new()
         // `GET /` goes to `root`
         .nest_service("/pkg", pkg_service)
         .nest_service("/static", static_service)
-        .fallback(leptos_axum::render_app_to_stream("/pkg/leptos_hackernews_axum", |cx| view! { cx, <App/> }));
+        .fallback(leptos_axum::render_app_to_stream(render_options, |cx| view! { cx, <App/> }));
 
         // run our app with hyper
         // `axum::Server` is a re-export of `hyper::Server`

--- a/examples/todo-app-cbor/src/main.rs
+++ b/examples/todo-app-cbor/src/main.rs
@@ -30,7 +30,7 @@ cfg_if! {
                     .service(Files::new("/pkg", "./pkg"))
                     .service(css)
                     .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
-                    .route("/{tail:.*}", leptos_actix::render_app_to_stream("todo_app_cbor", |cx| view! { cx, <TodoApp/> }))
+                    .route("/{tail:.*}", leptos_actix::render_app_to_stream("/pkg/todo_app_cbor", |cx| view! { cx, <TodoApp/> }))
                 //.wrap(middleware::Compress::default())
             })
             .bind(("127.0.0.1", 8081))?

--- a/examples/todo-app-sqlite-axum/src/main.rs
+++ b/examples/todo-app-sqlite-axum/src/main.rs
@@ -14,6 +14,7 @@ if #[cfg(feature = "ssr")] {
     use todo_app_sqlite_axum::*;
     use http::StatusCode;
     use tower_http::services::ServeDir;
+    use leptos_axum::RenderOptions;
 
     #[tokio::main]
     async fn main() {
@@ -44,13 +45,14 @@ if #[cfg(feature = "ssr")] {
             )
         }
 
+        let render_options: RenderOptions = leptos_axum::RenderOptionsBuilder::default().client_pkg_path("/pkg/todo_app_sqlite_axum").auto_reload(3001).build().expect("Failed to Parse RenderOptions");
 
         // build our application with a route
         let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
         .nest_service("/pkg", pkg_service)
         .nest_service("/static", static_service)
-        .fallback(leptos_axum::render_app_to_stream("/pkg/todo_app_sqlite_axum", |cx| view! { cx, <TodoApp/> }));
+        .fallback(leptos_axum::render_app_to_stream(render_options, |cx| view! { cx, <TodoApp/> }));
 
         // run our app with hyper
         // `axum::Server` is a re-export of `hyper::Server`

--- a/examples/todo-app-sqlite-axum/src/main.rs
+++ b/examples/todo-app-sqlite-axum/src/main.rs
@@ -50,7 +50,7 @@ if #[cfg(feature = "ssr")] {
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
         .nest_service("/pkg", pkg_service)
         .nest_service("/static", static_service)
-        .fallback(leptos_axum::render_app_to_stream("todo_app_sqlite_axum", |cx| view! { cx, <TodoApp/> }));
+        .fallback(leptos_axum::render_app_to_stream("/pkg/todo_app_sqlite_axum", |cx| view! { cx, <TodoApp/> }));
 
         // run our app with hyper
         // `axum::Server` is a re-export of `hyper::Server`

--- a/examples/todo-app-sqlite-axum/src/main.rs
+++ b/examples/todo-app-sqlite-axum/src/main.rs
@@ -14,7 +14,7 @@ if #[cfg(feature = "ssr")] {
     use todo_app_sqlite_axum::*;
     use http::StatusCode;
     use tower_http::services::ServeDir;
-    use leptos_axum::RenderOptions;
+    use std::env;
 
     #[tokio::main]
     async fn main() {
@@ -45,8 +45,9 @@ if #[cfg(feature = "ssr")] {
             )
         }
 
-        let render_options: RenderOptions = leptos_axum::RenderOptionsBuilder::default().client_pkg_path("/pkg/todo_app_sqlite_axum").auto_reload(3001).build().expect("Failed to Parse RenderOptions");
 
+        let render_options: RenderOptions = RenderOptions::builder().pkg_path("/pkg/todo_app_sqlite_axum").reload_port(3001).environment(&env::var("RUST_ENV")).build();
+        render_options.write_to_file();
         // build our application with a route
         let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))

--- a/examples/todo-app-sqlite-axum/src/todo.rs
+++ b/examples/todo-app-sqlite-axum/src/todo.rs
@@ -12,9 +12,9 @@ cfg_if! {
         }
 
         pub fn register_server_functions() {
-            GetTodos::register();
-            AddTodo::register();
-            DeleteTodo::register();
+            _ = GetTodos::register();
+            _ = AddTodo::register();
+            _ = DeleteTodo::register();
         }
 
         #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, sqlx::FromRow)]
@@ -34,7 +34,7 @@ cfg_if! {
 }
 
 #[server(GetTodos, "/api")]
-pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
+pub async fn get_todos(_cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
     // this is just an example of how to access server context injected in the handlers
     // http::Request doesn't implement Clone, so more work will be needed to do use_context() on this
     // let req = use_context::<http::Request<axum::body::BoxBody>>(cx)
@@ -70,7 +70,7 @@ pub async fn add_todo(title: String) -> Result<(), ServerFnError> {
         .execute(&mut conn)
         .await
     {
-        Ok(row) => Ok(()),
+        Ok(_row) => Ok(()),
         Err(e) => Err(ServerFnError::ServerError(e.to_string())),
     }
 }
@@ -167,7 +167,7 @@ pub fn Todos(cx: Scope) -> Element {
                                                                 <li>
                                                                     {todo.title}
                                                                     <ActionForm action=delete_todo.clone()>
-                                                                        <input type="hidden" name="id" value={todo.id}/>
+                                                                        <input type="hidden" name="id" value=todo.id/>
                                                                         <input type="submit" value="X"/>
                                                                     </ActionForm>
                                                                 </li>

--- a/examples/todo-app-sqlite/src/main.rs
+++ b/examples/todo-app-sqlite/src/main.rs
@@ -30,7 +30,7 @@ cfg_if! {
                     .service(Files::new("/pkg", "./pkg"))
                     .service(css)
                     .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
-                    .route("/{tail:.*}", leptos_actix::render_app_to_stream("todo_app_sqlite", |cx| view! { cx, <TodoApp/> }))
+                    .route("/{tail:.*}", leptos_actix::render_app_to_stream("/pkg/todo_app_sqlite", |cx| view! { cx, <TodoApp/> }))
                 //.wrap(middleware::Compress::default())
             })
             .bind(("127.0.0.1", 8083))?

--- a/examples/todo-app-sqlite/src/main.rs
+++ b/examples/todo-app-sqlite/src/main.rs
@@ -9,6 +9,7 @@ cfg_if! {
         use actix_files::{Files};
         use actix_web::*;
         use crate::todo::*;
+        use std::env;
 
         #[get("/style.css")]
         async fn css() -> impl Responder {
@@ -26,11 +27,14 @@ cfg_if! {
             crate::todo::register_server_functions();
 
             HttpServer::new(|| {
+                let render_options: RenderOptions = RenderOptions::builder().pkg_path("/pkg/todo_app_sqlite").reload_port(3001).environment(&env::var("RUST_ENV")).build();
+                render_options.write_to_file();
+
                 App::new()
                     .service(Files::new("/pkg", "./pkg"))
                     .service(css)
                     .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
-                    .route("/{tail:.*}", leptos_actix::render_app_to_stream("/pkg/todo_app_sqlite", |cx| view! { cx, <TodoApp/> }))
+                    .route("/{tail:.*}", leptos_actix::render_app_to_stream(render_options, |cx| view! { cx, <TodoApp/> }))
                 //.wrap(middleware::Compress::default())
             })
             .bind(("127.0.0.1", 8083))?

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -138,7 +138,7 @@ pub fn handle_server_fns() -> Route {
 /// # }
 /// ```
 pub fn render_app_to_stream(
-    client_pkg_name: &'static str,
+    client_pkg_path: &'static str,
     app_fn: impl Fn(leptos::Scope) -> Element + Clone + 'static,
 ) -> Route {
     web::get().to(move |req: HttpRequest| {
@@ -170,7 +170,7 @@ pub fn render_app_to_stream(
                     <head>
                         <meta charset="utf-8"/>
                         <meta name="viewport" content="width=device-width, initial-scale=1"/>
-                        <script type="module">import init, {{ hydrate }} from '/pkg/{client_pkg_name}.js'; init().then(hydrate);</script>"#);
+                        <script type="module">import init, {{ hydrate }} from '{client_pkg_path}.js'; init().then(hydrate);</script>"#);
             let tail = "</body></html>";
 
             HttpResponse::Ok().content_type("text/html").streaming(

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -129,7 +129,7 @@ pub fn handle_server_fns() -> Route {
 ///         App::new()
 ///             // {tail:.*} passes the remainder of the URL as the route
 ///             // the actual routing will be handled by `leptos_router`
-///             .route("/{tail:.*}", leptos_actix::render_app_to_stream("leptos_example", |cx| view! { cx, <MyApp/> }))
+///             .route("/{tail:.*}", leptos_actix::render_app_to_stream("/pkg/leptos_example", |cx| view! { cx, <MyApp/> }))
 ///     })
 ///     .bind(("127.0.0.1", 8080))?
 ///     .run()

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -9,6 +9,7 @@ description = "Axum integrations for the Leptos web framework."
 
 [dependencies]
 axum = "0.6"
+derive_builder = "0.12.0"
 futures = "0.3"
 leptos = { path = "../../leptos", default-features = false, version = "0.0", features = [
 	"ssr",

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -11,6 +11,7 @@ description = "Axum integrations for the Leptos web framework."
 axum = "0.6"
 derive_builder = "0.12.0"
 futures = "0.3"
+kdl = "4.6.0"
 leptos = { path = "../../leptos", default-features = false, version = "0.0", features = [
 	"ssr",
 ] }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -156,7 +156,7 @@ pub type PinnedHtmlStream = Pin<Box<dyn Stream<Item = io::Result<Bytes>> + Send>
 ///
 ///     // build our application with a route
 ///     let app = Router::new()
-///     .fallback(leptos_axum::render_app_to_stream("leptos_example", |cx| view! { cx, <MyApp/> }));
+///     .fallback(leptos_axum::render_app_to_stream("/pkg/leptos_example", |cx| view! { cx, <MyApp/> }));
 ///
 ///     // run our app with hyper
 ///     // `axum::Server` is a re-export of `hyper::Server`
@@ -168,7 +168,7 @@ pub type PinnedHtmlStream = Pin<Box<dyn Stream<Item = io::Result<Bytes>> + Send>
 /// # }
 /// ```
 pub fn render_app_to_stream(
-    client_pkg_name: &'static str,
+    client_pkg_path: &'static str,
     app_fn: impl Fn(leptos::Scope) -> Element + Clone + Send + 'static,
 ) -> impl Fn(
     Request<Body>,
@@ -197,7 +197,7 @@ pub fn render_app_to_stream(
                         <head>
                             <meta charset="utf-8"/>
                             <meta name="viewport" content="width=device-width, initial-scale=1"/>
-                            <script type="module">import init, {{ hydrate }} from '/pkg/{client_pkg_name}.js'; init().then(hydrate);</script>"#
+                            <script type="module">import init, {{ hydrate }} from '{client_pkg_path}.js'; init().then(hydrate);</script>"#
                 );
                 let tail = "</body></html>";
 

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -4,12 +4,12 @@ use axum::{
     http::{HeaderMap, HeaderValue, Request, StatusCode},
     response::{IntoResponse, Response},
 };
+use derive_builder::Builder;
 use futures::{Future, SinkExt, Stream, StreamExt};
 use leptos::*;
 use leptos_meta::MetaContext;
 use leptos_router::*;
 use std::{io, pin::Pin, sync::Arc};
-
 /// An Axum handlers to listens for a request with Leptos server function arguments in the body,
 /// run the server function if found, and return the resulting [Response].
 ///
@@ -128,6 +128,14 @@ pub async fn handle_server_fns(
 
 pub type PinnedHtmlStream = Pin<Box<dyn Stream<Item = io::Result<Bytes>> + Send>>;
 
+#[derive(Default, Builder, Clone)]
+pub struct RenderOptions {
+    #[builder(setter(into))]
+    client_pkg_path: String,
+    #[builder(setter(strip_option), default)]
+    auto_reload: Option<u32>,
+}
+
 /// Returns an Axum [Handler](axum::handler::Handler) that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an HTML stream of your application.
 ///
@@ -167,8 +175,9 @@ pub type PinnedHtmlStream = Pin<Box<dyn Stream<Item = io::Result<Bytes>> + Send>
 /// }
 /// # }
 /// ```
+///
 pub fn render_app_to_stream(
-    client_pkg_path: &'static str,
+    options: RenderOptions,
     app_fn: impl Fn(leptos::Scope) -> Element + Clone + Send + 'static,
 ) -> impl Fn(
     Request<Body>,
@@ -178,6 +187,7 @@ pub fn render_app_to_stream(
        + 'static {
     move |req: Request<Body>| {
         Box::pin({
+            let options = options.clone();
             let app_fn = app_fn.clone();
             async move {
                 // Need to get the path and query string of the Request
@@ -191,13 +201,34 @@ pub fn render_app_to_stream(
                     full_path = "http://leptos".to_string() + &path.to_string()
                 }
 
+                let client_pkg_path = &options.client_pkg_path;
+
+                let leptos_autoreload = match options.auto_reload {
+                    Some(port) => format!(
+                        r#"
+                            <script crossorigin="">(function () {{
+                                var ws = new WebSocket('ws://127.0.0.1:{port}/autoreload');
+                                ws.onmessage = (ev) => {{
+                                    console.log(`Reload message: `);
+                                    if (ev.data === 'reload') window.location.reload();
+                                }};
+                                ws.onclose = () => console.warn('Autoreload stopped. Manual reload necessary.');
+                            }})()
+                            </script>
+                        "#
+                    ),
+                    None => "".to_string(),
+                };
+
                 let head = format!(
                     r#"<!DOCTYPE html>
                     <html lang="en">
                         <head>
                             <meta charset="utf-8"/>
                             <meta name="viewport" content="width=device-width, initial-scale=1"/>
-                            <script type="module">import init, {{ hydrate }} from '{client_pkg_path}.js'; init().then(hydrate);</script>"#
+                            <script type="module">import init, {{ hydrate }} from '{client_pkg_path}.js'; init().then(hydrate);</script>
+                            {leptos_autoreload}
+                            "#
                 );
                 let tail = "</body></html>";
 

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 
 [dependencies]
 leptos_core = { path = "../leptos_core", default-features = false, version = "0.0.19" }
+leptos_config = { path = "../leptos_config", default-features = false, version = "0.0.1" }
 leptos_dom = { path = "../leptos_dom", default-features = false, version = "0.0.19" }
 leptos_macro = { path = "../leptos_macro", default-features = false, version = "0.0.19" }
 leptos_reactive = { path = "../leptos_reactive", default-features = false, version = "0.0.19" }

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -141,6 +141,7 @@
 //! # }
 //! ```
 
+pub use leptos_config::*;
 pub use leptos_core::*;
 pub use leptos_dom;
 pub use leptos_dom::wasm_bindgen::{JsCast, UnwrapThrowExt};

--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "leptos_config"
+version = "0.0.1"
+edition = "2021"
+authors = ["Greg Johnston"]
+license = "MIT"
+repository = "https://github.com/gbj/leptos"
+description = "Configuraiton for Leptos"
+
+[dependencies]
+typed-builder = "0.11.0"

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -1,0 +1,83 @@
+use std::{env::VarError, str::FromStr};
+use typed_builder::TypedBuilder;
+
+#[derive(Default, TypedBuilder, Clone)]
+pub struct RenderOptions {
+    #[builder(setter(into))]
+    pub pkg_path: String,
+    #[builder(setter(into))]
+    pub environment: RustEnv,
+    #[builder(setter(strip_option), default)]
+    pub reload_port: Option<u32>,
+}
+
+impl RenderOptions {
+    /// Creates a hidden file at ./.leptos_toml so cargo-leptos can monitor settings
+    pub fn write_to_file(&self) {
+        use std::fs;
+        let options = format!(
+            r#"render_options: {{
+    pkg_path {}
+    environment {:?}
+    reload_port {:?}
+}}
+"#,
+            self.pkg_path, self.environment, self.reload_port
+        );
+        fs::write("./.leptos.kdl", options).expect("Unable to write file");
+    }
+}
+#[derive(Default, Debug, Clone)]
+pub enum RustEnv {
+    #[default]
+    PROD,
+    DEV,
+}
+
+impl FromStr for RustEnv {
+    type Err = ();
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let sanitized = input.to_lowercase();
+        match sanitized.as_ref() {
+            "dev" => Ok(Self::DEV),
+            "development" => Ok(Self::DEV),
+            "prod" => Ok(Self::PROD),
+            "production" => Ok(Self::PROD),
+            _ => Ok(Self::PROD),
+        }
+    }
+}
+
+impl From<&str> for RustEnv {
+    fn from(str: &str) -> Self {
+        let sanitized = str.to_lowercase();
+        match sanitized.as_str() {
+            "dev" => Self::DEV,
+            "development" => Self::DEV,
+            "prod" => Self::PROD,
+            "production" => Self::PROD,
+            _ => {
+                panic!("Environment var is not recognized. Maybe try `dev` or `prod`")
+            }
+        }
+    }
+}
+impl From<&Result<String, VarError>> for RustEnv {
+    fn from(input: &Result<String, VarError>) -> Self {
+        match input {
+            Ok(str) => {
+                let sanitized = str.to_lowercase();
+                match sanitized.as_ref() {
+                    "dev" => Self::DEV,
+                    "development" => Self::DEV,
+                    "prod" => Self::PROD,
+                    "production" => Self::PROD,
+                    _ => {
+                        panic!("Environment var is not recognized. Maybe try `dev` or `prod`")
+                    }
+                }
+            }
+            Err(_) => Self::PROD,
+        }
+    }
+}


### PR DESCRIPTION
In an attempt to standardize config with cargo-leptos and use our integrations, I've modified leptos to have a central config for SSR, and to generate a KDL file with config params for cargo-leptos to read.

I also updated the todo-sqlite and todo-sqlite-axum to show what that would look like.

I'd love to get input on this structure. I haven't fixed the tests or most of the examples yet, so this is WIP