### PR TITLE
update_returning handlers

### DIFF
--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -123,6 +123,11 @@ pub trait UntrackedSettableSignal<T> {
     /// Runs the provided closure with a mutable reference to the current
     /// value without notifying dependents.
     fn update_untracked(&self, f: impl FnOnce(&mut T));
+
+    /// Runs the provided closure with a mutable reference to the current
+    /// value without notifying dependents and returns
+    /// the value the closure returned.
+    fn update_returning_untracked<U>(&self, f: impl FnOnce(&mut T) -> U) -> Option<U>;
 }
 
 #[doc(hidden)]

--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -36,7 +36,9 @@ impl SuspenseContext {
     /// Notifies the suspense context that a new resource is now pending.
     pub fn increment(&self) {
         let setter = self.set_pending_resources;
-        queue_microtask(move || setter.update(|n| *n += 1));
+        queue_microtask(move || {
+            setter.update(|n| *n += 1);
+        });
     }
 
     /// Notifies the suspense context that a resource has resolved.
@@ -47,7 +49,7 @@ impl SuspenseContext {
                 if *n > 0 {
                     *n -= 1
                 }
-            })
+            });
         });
     }
 


### PR DESCRIPTION
added update_returning variants to all Signal types, update_returning runs the closure and then returns its return value. Since the closure isn't guaranteed to be run, update_returning has to return Option<U>