### PR TITLE
Fix example tailwind

### DIFF
--- a/examples/tailwind/README.md
+++ b/examples/tailwind/README.md
@@ -8,9 +8,9 @@ If you don't have `cargo-leptos` installed you can install it with
 
 Then run
 
-`npx tailwindcss -i ./input.css -o ./style/output.scss --watch`
+`npx tailwindcss -i ./input.css -o ./style/output.css --watch`
 
-and 
+and
 
 `cargo leptos watch`
 


### PR DESCRIPTION
Hi,

Thanks for this project !

In example/tailwind, readme says `-o ./style/output.scss`, so I guess this is the one we should look at.

Otherwise:
```
╰─>$ cargo leptos watch
Error: at `/home/nim/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-leptos-0.0.9/src/main.rs@104:58`

Caused by:
    no css/sass/scss file found at: "style/output.css"