### PR TITLE
fix warning, set initial value of counter

### DIFF
--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -9,7 +9,7 @@ use leptos::*;
 /// - **step** [`i32`] - The change that should be applied on each step.
 #[component]
 pub fn SimpleCounter(cx: Scope, initial_value: i32, step: i32) -> web_sys::Element {
-    let (value, set_value) = create_signal(cx, 0);
+    let (value, set_value) = create_signal(cx, initial_value);
 
     view! { cx,
         <div>


### PR DESCRIPTION
trying out `leptos` for the first time, I noticed a warning in this example, which pointed to what appears to be a bug:

```
warning: unused variable: `initial_value`
  --> examples/counter/src/lib.rs:11:33
   |
11 | pub fn SimpleCounter(cx: Scope, initial_value: i32, step: i32) -> web_sys::Element {
   |                                 ^^^^^^^^^^^^^ help: try ignoring the field: `initial_value: _`
   |
   = note: `#[warn(unused_variables)]` on by default
```

I think this resolves the problem