### PR TITLE
Fix build errors in `counter-isomorphic` when using `stable`

### DIFF
--- a/examples/counter-isomorphic/src/counters.rs
+++ b/examples/counter-isomorphic/src/counters.rs
@@ -228,7 +228,7 @@ pub fn MultiuserCounter(cx: Scope) -> Element {
             <div>
                 <button on:click=move |_| clear.dispatch(())>"Clear"</button>
                 <button on:click=move |_| dec.dispatch(())>"-1"</button>
-                <span>"Multiplayer Value: " {move || multiplayer_value().unwrap_or_default().to_string()}</span>
+                <span>"Multiplayer Value: " {move || multiplayer_value.get().unwrap_or_default().to_string()}</span>
                 <button on:click=move |_| inc.dispatch(())>"+1"</button>
             </div>
         </div>

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -134,7 +134,7 @@ where
 
     cfg_if! {
         if #[cfg(feature = "stable")] {
-            let on_submit = move |ev: web_sys::Event| on_submit(ev.unchecked_into());
+            let on_submit = move |ev: web_sys::SubmitEvent| on_submit(ev.unchecked_into());
         }
     };
 
@@ -307,7 +307,7 @@ where
 
     cfg_if! {
         if #[cfg(feature = "stable")] {
-            let on_submit = move |ev: web_sys::Event| on_submit(ev.unchecked_into());
+            let on_submit = move |ev: web_sys::SubmitEvent| on_submit(ev.unchecked_into());
         }
     };
 

--- a/router/src/components/link.rs
+++ b/router/src/components/link.rs
@@ -128,8 +128,8 @@ where
         } else {
             view! { cx,
                 <a
-                    href=move || href().unwrap_or_default()
-                    aria-current=move || if is_active() { Some("page") } else { None }
+                    href=move || href.get().unwrap_or_default()
+                    aria-current=move || if is_active.get() { Some("page") } else { None }
                     class=move || class.as_ref().map(|class| class.get())
                 >
                     {child}


### PR DESCRIPTION
I'm investigating using this framework, but prefer to use stable Rust, so just a couple of fixes to get the `counter-isomorphic` example building when enabling the `stable` feature.

Tested by enabling stable in the [counter isomorphic deps](https://gist.github.com/snapbug/49e0ad2512511e2ef86c85d9ea761a37), and building. Checked functionality remains correct for all the methods shown in both Safari and Chrome.

Note: I don't know that editing the example is necessarily a completely desireable fix, given the separation of `counter` and `counters-stable`, and I also noted in router/src/components/link.rs that there is a cfg_if separation of csr or hydrate and not, whereas components/form.rs also has a stable/not cfg_if.