### PR TITLE
`store_value`

### DIFF
--- a/examples/counter-isomorphic/src/counters.rs
+++ b/examples/counter-isomorphic/src/counters.rs
@@ -90,7 +90,7 @@ pub fn Counter(cx: Scope) -> impl IntoView {
     let clear = create_action(cx, |_| clear_server_count());
     let counter = create_resource(
         cx,
-        move || (dec.version.get(), inc.version.get(), clear.version.get()),
+        move || (dec.version().get(), inc.version().get(), clear.version().get()),
         |_| get_server_count(),
     );
 
@@ -130,14 +130,9 @@ pub fn FormCounter(cx: Scope) -> impl IntoView {
 
     let counter = create_resource(
         cx,
-        {
-            let adjust = adjust.version;
-            let clear = clear.version;
-            move || (adjust.get(), clear.get())
-        },
+        move || (adjust.version().get(), clear.version().get()),
         |_| {
             log::debug!("FormCounter running fetcher");
-
             get_server_count()
         },
     );
@@ -150,8 +145,6 @@ pub fn FormCounter(cx: Scope) -> impl IntoView {
             .map(|n| n)
             .unwrap_or(0)
     };
-
-    let adjust2 = adjust.clone();
 
     view! {
         cx,
@@ -172,7 +165,7 @@ pub fn FormCounter(cx: Scope) -> impl IntoView {
                     <input type="submit" value="-1"/>
                 </ActionForm>
                 <span>"Value: " {move || value().to_string()} "!"</span>
-                <ActionForm action=adjust2>
+                <ActionForm action=adjust>
                     <input type="hidden" name="delta" value="1"/>
                     <input type="hidden" name="msg" value="form value up"/>
                     <input type="submit" value="+1"/>

--- a/examples/todo-app-sqlite-axum/src/todo.rs
+++ b/examples/todo-app-sqlite-axum/src/todo.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 cfg_if! {
     if #[cfg(feature = "ssr")] {
         use sqlx::{Connection, SqliteConnection};
+        use http::{header::SET_COOKIE, HeaderMap, HeaderValue, StatusCode};
 
         pub async fn db() -> Result<SqliteConnection, ServerFnError> {
             Ok(SqliteConnection::connect("sqlite:Todos.db").await.map_err(|e| ServerFnError::ServerError(e.to_string()))?)
@@ -37,9 +38,10 @@ cfg_if! {
 #[server(GetTodos, "/api")]
 pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
     // this is just an example of how to access server context injected in the handlers
-    let req =
-        use_context::<actix_web::HttpRequest>(cx).expect("couldn't get HttpRequest from context");
-    println!("req.path = {:?}", req.path());
+    // http::Request doesn't implement Clone, so more work will be needed to do use_context() on this
+    let req_parts = use_context::<leptos_axum::RequestParts>(cx).unwrap();
+    println!("\ncalling server fn");
+    println!("Uri = {:?}", req_parts.uri);
 
     use futures::TryStreamExt;
 
@@ -53,6 +55,20 @@ pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
         .map_err(|e| ServerFnError::ServerError(e.to_string()))?
     {
         todos.push(row);
+    }
+
+    // Add a random header(because why not)
+    let mut res_headers = HeaderMap::new();
+    res_headers.insert(SET_COOKIE, HeaderValue::from_str("fizz=buzz").unwrap());
+
+    let res_parts = leptos_axum::ResponseParts {
+        headers: res_headers,
+        status: Some(StatusCode::IM_A_TEAPOT),
+    };
+
+    let res_options_outer = use_context::<leptos_axum::ResponseOptions>(cx);
+    if let Some(res_options) = res_options_outer {
+        res_options.overwrite(res_parts).await;
     }
 
     Ok(todos)
@@ -70,7 +86,7 @@ pub async fn add_todo(title: String) -> Result<(), ServerFnError> {
         .execute(&mut conn)
         .await
     {
-        Ok(row) => Ok(()),
+        Ok(_row) => Ok(()),
         Err(e) => Err(ServerFnError::ServerError(e.to_string())),
     }
 }

--- a/examples/todo-app-sqlite/src/todo.rs
+++ b/examples/todo-app-sqlite/src/todo.rs
@@ -104,7 +104,7 @@ pub fn TodoApp(cx: Scope) -> impl IntoView {
                     }/>
                 </Routes>
             </main>
-        </Router> 
+        </Router>
     }
 }
 
@@ -114,14 +114,10 @@ pub fn Todos(cx: Scope) -> impl IntoView {
     let delete_todo = create_server_action::<DeleteTodo>(cx);
     let submissions = add_todo.submissions();
 
-    // track mutations that should lead us to refresh the list
-    let add_changed = add_todo.version;
-    let todo_deleted = delete_todo.version;
-
     // list of todos is loaded from the server in reaction to changes
     let todos = create_resource(
         cx,
-        move || (add_changed(), todo_deleted()),
+        move || (add_todo.version().get(), delete_todo.version().get()),
         move |_| get_todos(cx),
     );
 
@@ -136,17 +132,11 @@ pub fn Todos(cx: Scope) -> impl IntoView {
                 <input type="submit" value="Add"/>
             </MultiActionForm>
             <Transition fallback=move || view! {cx, <p>"Loading..."</p> }>
-                {
-                    let delete_todo = delete_todo.clone();
-                    move || {
+                {move || {
                     let existing_todos = {
-                        let delete_todo = delete_todo.clone();
                         move || {
-                            todos
-                            .read()
-                            .map({
-                                let delete_todo = delete_todo.clone();
-                                move |todos| match todos {
+                            todos.read()
+                                .map(move |todos| match todos {
                                     Err(e) => {
                                         vec![view! { cx, <pre class="error">"Server Error: " {e.to_string()}</pre>}.into_any()]
                                     }
@@ -156,29 +146,24 @@ pub fn Todos(cx: Scope) -> impl IntoView {
                                         } else {
                                             todos
                                                 .into_iter()
-                                                .map({
-                                                    let delete_todo = delete_todo.clone();
-                                                    move |todo| {
-                                                        let delete_todo = delete_todo.clone();
-                                                        view! {
-                                                            cx,
-                                                            <li>
-                                                                {todo.title}
-                                                                <ActionForm action=delete_todo.clone()>
-                                                                    <input type="hidden" name="id" value={todo.id}/>
-                                                                    <input type="submit" value="X"/>
-                                                                </ActionForm>
-                                                            </li>
-                                                        }
-                                                        .into_any()
+                                                .map(move |todo| {
+                                                    view! {
+                                                        cx,
+                                                        <li>
+                                                            {todo.title}
+                                                            <ActionForm action=delete_todo>
+                                                                <input type="hidden" name="id" value={todo.id}/>
+                                                                <input type="submit" value="X"/>
+                                                            </ActionForm>
+                                                        </li>
                                                     }
+                                                    .into_any()
                                                 })
                                                 .collect::<Vec<_>>()
                                         }
                                     }
-                                }
-                            })
-                            .unwrap_or_default()
+                                })
+                                .unwrap_or_default()
                         }
                     };
 

--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -79,6 +79,7 @@ mod signal;
 mod signal_wrappers_read;
 mod signal_wrappers_write;
 mod spawn;
+mod stored_value;
 mod suspense;
 
 pub use context::*;
@@ -94,6 +95,7 @@ pub use signal::*;
 pub use signal_wrappers_read::*;
 pub use signal_wrappers_write::*;
 pub use spawn::*;
+pub use stored_value::*;
 pub use suspense::*;
 
 /// Trait implemented for all signal types which you can `get` a value

--- a/leptos_reactive/src/stored_value.rs
+++ b/leptos_reactive/src/stored_value.rs
@@ -1,0 +1,181 @@
+use crate::{create_rw_signal, RwSignal, Scope, UntrackedGettableSignal, UntrackedSettableSignal};
+
+/// A **non-reactive** wrapper for any value, which can be created with [store_value].
+///
+/// If you want a reactive wrapper, use [create_signal](crate::create_signal).
+///
+/// This allows you to create a stable reference for any value by storing it within
+/// the reactive system. Like the signal types (e.g., [ReadSignal](crate::ReadSignal)
+/// and [RwSignal](crate::RwSignal)), it is `Copy` and `'static`. Unlike the signal
+/// types, it is not reactive; accessing it does not cause effects to subscribe, and
+/// updating it does not notify anything else.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct StoredValue<T>(RwSignal<T>)
+where
+    T: 'static;
+
+impl<T> Clone for StoredValue<T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+impl<T> Copy for StoredValue<T> {}
+
+impl<T> StoredValue<T>
+where
+    T: 'static,
+{
+    /// Clones and returns the current stored value.
+    ///
+    /// If you want to get the value without cloning it, use [StoredValue::with].
+    /// (`value.get()` is equivalent to `value.with(T::clone)`.)
+    /// ```
+    /// # use leptos_reactive::*;
+    /// # create_scope(create_runtime(), |cx| {
+    ///
+    /// #[derive(Clone)]
+    /// pub struct MyCloneableData {
+    ///   pub value: String
+    /// }
+    /// let data = store_value(cx, MyCloneableData { value: "a".into() });
+    ///
+    /// // calling .get() clones and returns the value
+    /// assert_eq!(data.get().value, "a");
+    /// // there's a short-hand getter form
+    /// assert_eq!(data().value, "a");
+    /// });
+    /// ```
+    pub fn get(&self) -> T
+    where
+        T: Clone,
+    {
+        self.with(T::clone)
+    }
+
+    /// Applies a function to the current stored value.
+    /// ```
+    /// # use leptos_reactive::*;
+    /// # create_scope(create_runtime(), |cx| {
+    ///
+    /// pub struct MyUncloneableData {
+    ///   pub value: String
+    /// }
+    /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
+    ///
+    /// // calling .with() to extract the value
+    /// assert_eq!(data.with(|data| data.value.clone()), "a");
+    /// });
+    /// ```
+    pub fn with<U>(&self, f: impl FnOnce(&T) -> U) -> U {
+        self.0.with_untracked(f)
+    }
+
+    /// Applies a function to the current value to mutate it in place.
+    /// ```
+    /// # use leptos_reactive::*;
+    /// # create_scope(create_runtime(), |cx| {
+    ///
+    /// pub struct MyUncloneableData {
+    ///   pub value: String
+    /// }
+    /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
+    /// data.update(|data| data.value = "b".into());
+    /// assert_eq!(data.with(|data| data.value.clone()), "b");
+    /// });
+    /// ```
+    pub fn update(&self, f: impl FnOnce(&mut T)) {
+        self.0.update_untracked(f);
+    }
+
+    /// Sets the stored value.
+    /// ```
+    /// # use leptos_reactive::*;
+    /// # create_scope(create_runtime(), |cx| {
+    ///
+    /// pub struct MyUncloneableData {
+    ///   pub value: String
+    /// }
+    /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
+    /// data.set(MyUncloneableData { value: "b".into() });
+    /// assert_eq!(data.with(|data| data.value.clone()), "b");
+    /// });
+    /// ```
+    pub fn set(&self, value: T) {
+        self.0.set_untracked(value);
+    }
+}
+
+/// Creates a **non-reactive** wrapper for any value by storing it within
+/// the reactive system.
+///
+/// Like the signal types (e.g., [ReadSignal](crate::ReadSignal)
+/// and [RwSignal](crate::RwSignal)), it is `Copy` and `'static`. Unlike the signal
+/// types, it is not reactive; accessing it does not cause effects to subscribe, and
+/// updating it does not notify anything else.
+/// ```compile_fail
+/// # use leptos_reactive::*;
+/// # create_scope(create_runtime(), |cx| {
+/// // this structure is neither `Copy` nor `Clone`
+/// pub struct MyUncloneableData {
+///   pub value: String
+/// }
+///
+/// // ❌ this won't compile, as it can't be cloned or copied into the closures
+/// let data = MyUncloneableData { value: "a".into() };
+/// let callback_a = move || data.value == "a";
+/// let callback_b = move || data.value == "b";
+/// # }).dispose();
+/// ```
+/// ```
+/// # use leptos_reactive::*;
+/// # create_scope(create_runtime(), |cx| {
+/// // this structure is neither `Copy` nor `Clone`
+/// pub struct MyUncloneableData {
+///   pub value: String
+/// }
+///
+/// // ✅ you can move the `StoredValue` and access it with .with()
+/// let data = store_value(cx, MyUncloneableData { value: "a".into() });
+/// let callback_a = move || data.with(|data| data.value == "a");
+/// let callback_b = move || data.with(|data| data.value == "b");
+/// # }).dispose();
+/// ```
+pub fn store_value<T>(cx: Scope, value: T) -> StoredValue<T>
+where
+    T: 'static,
+{
+    StoredValue(create_rw_signal(cx, value))
+}
+
+#[cfg(not(feature = "stable"))]
+impl<T> FnOnce<()> for StoredValue<T>
+where
+    T: Clone,
+{
+    type Output = T;
+
+    extern "rust-call" fn call_once(self, _args: ()) -> Self::Output {
+        self.get()
+    }
+}
+
+#[cfg(not(feature = "stable"))]
+impl<T> FnMut<()> for StoredValue<T>
+where
+    T: Clone,
+{
+    extern "rust-call" fn call_mut(&mut self, _args: ()) -> Self::Output {
+        self.get()
+    }
+}
+
+#[cfg(not(feature = "stable"))]
+impl<T> Fn<()> for StoredValue<T>
+where
+    T: Clone,
+{
+    extern "rust-call" fn call(&self, _args: ()) -> Self::Output {
+        self.get()
+    }
+}

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -144,11 +144,11 @@ where
         url
     } else {
         debug_warn!("<ActionForm/> action needs a URL. Either use create_server_action() or Action::using_server_fn().");
-        ""
-    }.to_string();
-    let version = action.version;
-    let value = action.value;
-    let input = action.input;
+        String::new()
+    };
+    let version = action.version();
+    let value = action.value();
+    let input = action.input();
 
     let on_form_data = Rc::new(move |form_data: &web_sys::FormData| {
         let data = action_input_from_form_data(form_data);
@@ -219,8 +219,8 @@ where
         url
     } else {
         debug_warn!("<MultiActionForm/> action needs a URL. Either use create_server_action() or Action::using_server_fn().");
-        ""
-    }.to_string();
+        String::new()
+    };
 
     let on_submit = move |ev: web_sys::SubmitEvent| {
         if ev.default_prevented() {


### PR DESCRIPTION
This PR allows you to store values in the reactive system, in exchange for non-reactive references that are `Copy` and `'static`. This means that any value can have the same `move`-ability and easy DX as the signal types, without triggering reactive updates.

This also migrates the `Signal` and `SignalSetter` wrapper types and the `Action` and `MultiAction` types so that they are backed by `StoredValue`s, which means that all of the framework's primitive types are `Copy`.