### PR TITLE
Closes #212

### DIFF
--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -699,7 +699,7 @@ macro_rules! generate_html_tags {
               ) {
                 #[cfg(debug_assertions)]
                 assert_eq!(
-                  el.node_name(),
+                  el.node_name().to_ascii_uppercase(),
                   stringify!([<$tag:upper>]),
                   "SSR and CSR elements have the same `TopoId` \
                     but different node kinds. This is either a \
@@ -716,7 +716,7 @@ macro_rules! generate_html_tags {
               ) {
                 #[cfg(debug_assertions)]
                 assert_eq!(
-                  el.node_name(),
+                  el.node_name().to_ascii_uppercase(),
                   stringify!([<$tag:upper>]),
                   "SSR and CSR elements have the same `TopoId` \
                     but different node kinds. This is either a \

--- a/leptos_dom/src/html/math.rs
+++ b/leptos_dom/src/html/math.rs
@@ -64,7 +64,7 @@ macro_rules! generate_math_tags {
               ) {
                 #[cfg(debug_assertions)]
                 assert_eq!(
-                  el.node_name(),
+                  el.node_name().to_ascii_uppercase(),
                   stringify!([<$tag:upper $(_ $second:upper $(_ $third:upper)?)?>]),
                   "SSR and CSR elements have the same `TopoId` \
                     but different node kinds. This is either a \
@@ -81,7 +81,7 @@ macro_rules! generate_math_tags {
               ) {
                 #[cfg(debug_assertions)]
                 assert_eq!(
-                  el.node_name(),
+                  el.node_name().to_ascii_uppercase(),
                   stringify!([<$tag:upper $(_ $second:upper $(_ $third:upper)?)?>]),
                   "SSR and CSR elements have the same `TopoId` \
                     but different node kinds. This is either a \

--- a/leptos_dom/src/html/svg.rs
+++ b/leptos_dom/src/html/svg.rs
@@ -61,7 +61,7 @@ macro_rules! generate_svg_tags {
               ) {
                 #[cfg(debug_assertions)]
                 assert_eq!(
-                  el.node_name(),
+                  el.node_name().to_ascii_uppercase(),
                   stringify!([<$tag:upper $(_ $second:upper $(_ $third:upper)?)?>]),
                   "SSR and CSR elements have the same `TopoId` \
                     but different node kinds. This is either a \
@@ -78,7 +78,7 @@ macro_rules! generate_svg_tags {
               ) {
                 #[cfg(debug_assertions)]
                 assert_eq!(
-                  el.node_name(),
+                  el.node_name().to_ascii_uppercase(),
                   stringify!([<$tag:upper $(_ $second:upper $(_ $third:upper)?)?>]),
                   "SSR and CSR elements have the same `TopoId` \
                     but different node kinds. This is either a \


### PR DESCRIPTION
Make sure all tag names are uppercased, which they're not for elements created with `document.createElementNS()`