### PR TITLE
Add a redirect() function and some helpful utility functions for ResponseParts and ResponseOptions

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -21,8 +21,8 @@ impl ResponseParts{
     pub fn insert_header(&mut self, key: header::HeaderName, value: header::HeaderValue){
         self.headers.insert(key, value);
     }
-     /// Insert a header, overwriting any previous value with the same key
-     pub fn append_header(&mut self, key: header::HeaderName, value: header::HeaderValue){
+    /// Append a header, leaving any header with the same key intact
+    pub fn append_header(&mut self, key: header::HeaderName, value: header::HeaderValue){
         self.headers.append(key, value);
     }
 }
@@ -39,8 +39,8 @@ impl ResponseOptions {
         let mut writable = self.0.write().await;
         *writable = parts
     }
-    /// Insert a header, overwriting any previous value with the same key
-    pub async fn status(&self, status: StatusCode){
+    /// Set the status of the returned Response
+    pub async fn set_status(&self, status: StatusCode){
         let mut writeable = self.0.write().await;
         let res_parts = &mut*writeable;
         res_parts.status = Some(status);
@@ -51,7 +51,7 @@ impl ResponseOptions {
         let res_parts = &mut*writeable;
         res_parts.headers.insert(key, value);
     }
-    /// Insert a header, overwriting any previous value with the same key
+    /// Append a header, leaving any header with the same key intact
     pub async fn append_header(&self, key: header::HeaderName, value: header::HeaderValue){
         let mut writeable = self.0.write().await;
         let res_parts = &mut*writeable;
@@ -64,7 +64,7 @@ impl ResponseOptions {
 /// If looking to redirect from the client, `leptos_router::use_navigate()` should be used instead
 pub async fn redirect(cx: leptos::Scope, path: &str){
     let response_options = use_context::<ResponseOptions>(cx).unwrap();
-    response_options.status(StatusCode::FOUND).await;
+    response_options.set_status(StatusCode::FOUND).await;
     response_options.insert_header(header::LOCATION, header::HeaderValue::from_str(path).expect("Failed to create HeaderValue")).await;
 }
 

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1,4 +1,4 @@
-use actix_web::{http::header::HeaderMap, web::Bytes, *};
+use actix_web::{http::header, web::Bytes, *};
 use futures::{StreamExt}; 
 
 use http::StatusCode;
@@ -12,8 +12,19 @@ use tokio::sync::RwLock;
 /// Typically contained inside of a ResponseOptions. Setting this is useful for cookies and custom responses.
 #[derive(Debug, Clone, Default)]
 pub struct ResponseParts {
-    pub headers: HeaderMap,
+    pub headers: header::HeaderMap,
     pub status: Option<StatusCode>,
+}
+
+impl ResponseParts{
+    /// Insert a header, overwriting any previous value with the same key
+    pub fn insert_header(&mut self, key: header::HeaderName, value: header::HeaderValue){
+        self.headers.insert(key, value);
+    }
+     /// Insert a header, overwriting any previous value with the same key
+     pub fn append_header(&mut self, key: header::HeaderName, value: header::HeaderValue){
+        self.headers.append(key, value);
+    }
 }
 
 /// Adding this Struct to your Scope inside of a Server Fn or Elements will allow you to override details of the Response
@@ -28,6 +39,33 @@ impl ResponseOptions {
         let mut writable = self.0.write().await;
         *writable = parts
     }
+    /// Insert a header, overwriting any previous value with the same key
+    pub async fn status(&self, status: StatusCode){
+        let mut writeable = self.0.write().await;
+        let res_parts = &mut*writeable;
+        res_parts.status = Some(status);
+    }
+    /// Insert a header, overwriting any previous value with the same key
+    pub async fn insert_header(&self, key: header::HeaderName, value: header::HeaderValue){
+        let mut writeable = self.0.write().await;
+        let res_parts = &mut*writeable;
+        res_parts.headers.insert(key, value);
+    }
+    /// Insert a header, overwriting any previous value with the same key
+    pub async fn append_header(&self, key: header::HeaderName, value: header::HeaderValue){
+        let mut writeable = self.0.write().await;
+        let res_parts = &mut*writeable;
+        res_parts.headers.append(key, value);
+    }
+}
+
+/// Provides an easy way to redirect the user from within a server function. Mimicing the Remix `redirect()`,
+/// it sets a StatusCode of 302 and a LOCATION header with the provided value.
+/// If looking to redirect from the client, `leptos_router::use_navigate()` should be used instead
+pub async fn redirect(cx: leptos::Scope, path: &str){
+    let response_options = use_context::<ResponseOptions>(cx).unwrap();
+    response_options.status(StatusCode::FOUND).await;
+    response_options.insert_header(header::LOCATION, header::HeaderValue::from_str(path).expect("Failed to create HeaderValue")).await;
 }
 
 /// An Actix [Route](actix_web::Route) that listens for a `POST` request with

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1,11 +1,11 @@
 use axum::{
     body::{Body, Bytes, Full, StreamBody},
     extract::Path,
-    http::{HeaderMap, HeaderValue, Request, StatusCode},
+    http::{header::HeaderName, header::HeaderValue, HeaderMap, Request, StatusCode},
     response::IntoResponse,
 };
 use futures::{Future, SinkExt, Stream, StreamExt};
-use http::{method::Method, uri::Uri, version::Version, Response};
+use http::{header, method::Method, uri::Uri, version::Version, Response};
 use hyper::body;
 use leptos::*;
 use leptos_meta::MetaContext;
@@ -31,6 +31,17 @@ pub struct ResponseParts {
     pub headers: HeaderMap,
 }
 
+impl ResponseParts {
+    /// Insert a header, overwriting any previous value with the same key
+    pub fn insert_header(&mut self, key: HeaderName, value: HeaderValue) {
+        self.headers.insert(key, value);
+    }
+    /// Insert a header, overwriting any previous value with the same key
+    pub fn append_header(&mut self, key: HeaderName, value: HeaderValue) {
+        self.headers.append(key, value);
+    }
+}
+
 /// Adding this Struct to your Scope inside of a Server Fn or Element will allow you to override details of the Response
 /// like status and add Headers/Cookies. Because Elements and Server Fns are lower in the tree than the Response generation
 /// code, it needs to be wrapped in an `Arc<RwLock<>>` so that it can be surfaced.
@@ -38,11 +49,43 @@ pub struct ResponseParts {
 pub struct ResponseOptions(pub Arc<RwLock<ResponseParts>>);
 
 impl ResponseOptions {
-    /// A less boilerplatey way to overwrite the default contents of `ResponseOptions` with a new `ResponseParts`
+    /// A less boilerplatey way to overwrite the contents of `ResponseOptions` with a new `ResponseParts`
     pub async fn overwrite(&self, parts: ResponseParts) {
         let mut writable = self.0.write().await;
         *writable = parts
     }
+    /// Insert a header, overwriting any previous value with the same key
+    pub async fn status(&self, status: StatusCode) {
+        let mut writeable = self.0.write().await;
+        let res_parts = &mut *writeable;
+        res_parts.status = Some(status);
+    }
+    /// Insert a header, overwriting any previous value with the same key
+    pub async fn insert_header(&self, key: HeaderName, value: HeaderValue) {
+        let mut writeable = self.0.write().await;
+        let res_parts = &mut *writeable;
+        res_parts.headers.insert(key, value);
+    }
+    /// Insert a header, overwriting any previous value with the same key
+    pub async fn append_header(&self, key: HeaderName, value: HeaderValue) {
+        let mut writeable = self.0.write().await;
+        let res_parts = &mut *writeable;
+        res_parts.headers.append(key, value);
+    }
+}
+
+/// Provides an easy way to redirect the user from within a server function. Mimicing the Remix `redirect()`,
+/// it sets a StatusCode of 302 and a LOCATION header with the provided value.
+/// If looking to redirect from the client, `leptos_router::use_navigate()` should be used instead
+pub async fn redirect(cx: leptos::Scope, path: &str) {
+    let response_options = use_context::<ResponseOptions>(cx).unwrap();
+    response_options.status(StatusCode::FOUND).await;
+    response_options
+        .insert_header(
+            header::LOCATION,
+            header::HeaderValue::from_str(path).expect("Failed to create HeaderValue"),
+        )
+        .await;
 }
 
 pub async fn generate_request_parts(req: Request<Body>) -> RequestParts {

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -36,7 +36,7 @@ impl ResponseParts {
     pub fn insert_header(&mut self, key: HeaderName, value: HeaderValue) {
         self.headers.insert(key, value);
     }
-    /// Insert a header, overwriting any previous value with the same key
+    /// Append a header, leaving any header with the same key intact
     pub fn append_header(&mut self, key: HeaderName, value: HeaderValue) {
         self.headers.append(key, value);
     }
@@ -54,8 +54,8 @@ impl ResponseOptions {
         let mut writable = self.0.write().await;
         *writable = parts
     }
-    /// Insert a header, overwriting any previous value with the same key
-    pub async fn status(&self, status: StatusCode) {
+    /// Set the status of the returned Response
+    pub async fn set_status(&self, status: StatusCode) {
         let mut writeable = self.0.write().await;
         let res_parts = &mut *writeable;
         res_parts.status = Some(status);
@@ -66,7 +66,7 @@ impl ResponseOptions {
         let res_parts = &mut *writeable;
         res_parts.headers.insert(key, value);
     }
-    /// Insert a header, overwriting any previous value with the same key
+    /// Append a header, leaving any header with the same key intact
     pub async fn append_header(&self, key: HeaderName, value: HeaderValue) {
         let mut writeable = self.0.write().await;
         let res_parts = &mut *writeable;
@@ -79,7 +79,7 @@ impl ResponseOptions {
 /// If looking to redirect from the client, `leptos_router::use_navigate()` should be used instead
 pub async fn redirect(cx: leptos::Scope, path: &str) {
     let response_options = use_context::<ResponseOptions>(cx).unwrap();
-    response_options.status(StatusCode::FOUND).await;
+    response_options.set_status(StatusCode::FOUND).await;
     response_options
         .insert_header(
             header::LOCATION,


### PR DESCRIPTION
Inspired by your video and Remix's `redirect()`, I've added some helper functions to ResponseParts/ResponseOptions, and a handy `redirect()` function for easy redirection in server functions.

So this code
```rust
 let response =
        use_context::<ResponseOptions>(cx).expect("to have leptos_actix::ResponseOptions provided");
    let mut response_parts = ResponseParts::default();
    let mut headers = HeaderMap::new();
    headers.insert(
        SET_COOKIE,
        HeaderValue::from_str(&format!("darkmode={prefers_dark}; Path=/"))
            .expect("to create header value"),
    );
    response_parts.headers = headers;

    std::thread::sleep(std::time::Duration::from_millis(250));

    response.overwrite(response_parts).await;
```
could be this now:
```rust
let mut response = use_context::<ResponseOptions>(cx).expect("to have leptos_actix::ResponseOptions provided");
response.insert_header( SET_COOKIE, HeaderValue::from_str(&format!("darkmode={prefers_dark}; Path=/")).expect("to create header value"),)
std::thread::sleep(std::time::Duration::from_millis(250));
```