### PR TITLE
Add all the missing `router` tests

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -186,7 +186,8 @@
 mod components;
 mod history;
 mod hooks;
-mod matching;
+#[doc(hidden)]
+pub mod matching;
 
 pub use components::*;
 pub use history::*;

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -3,9 +3,9 @@ mod matcher;
 mod resolve_path;
 mod route;
 
-pub(crate) use expand_optionals::*;
-pub(crate) use matcher::*;
-pub(crate) use resolve_path::*;
+pub use expand_optionals::*;
+pub use matcher::*;
+pub use resolve_path::*;
 pub use route::*;
 
 use crate::RouteData;

--- a/router/tests/expand_optionals.rs
+++ b/router/tests/expand_optionals.rs
@@ -1,0 +1,35 @@
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(not(any(feature = "csr", feature = "hydrate")))] {
+        use leptos_router::expand_optionals;
+
+        #[test]
+        fn expand_optionals_should_expand() {
+            assert_eq!(expand_optionals("/foo/:x"), vec!["/foo/:x"]);
+            assert_eq!(expand_optionals("/foo/:x?"), vec!["/foo", "/foo/:x"]);
+            assert_eq!(expand_optionals("/bar/:x?/"), vec!["/bar/", "/bar/:x/"]);
+            assert_eq!(
+                expand_optionals("/foo/:x?/:y?/:z"),
+                vec!["/foo/:z", "/foo/:x/:z", "/foo/:x/:y/:z"]
+            );
+            assert_eq!(
+                expand_optionals("/foo/:x?/:y/:z?"),
+                vec!["/foo/:y", "/foo/:x/:y", "/foo/:y/:z", "/foo/:x/:y/:z"]
+            );
+            assert_eq!(
+                expand_optionals("/foo/:x?/bar/:y?/baz/:z?"),
+                vec![
+                    "/foo/bar/baz",
+                    "/foo/:x/bar/baz",
+                    "/foo/bar/:y/baz",
+                    "/foo/:x/bar/:y/baz",
+                    "/foo/bar/baz/:z",
+                    "/foo/:x/bar/baz/:z",
+                    "/foo/bar/:y/baz/:z",
+                    "/foo/:x/bar/:y/baz/:z"
+                ]
+            )
+        }
+    }
+}

--- a/router/tests/join_paths.rs
+++ b/router/tests/join_paths.rs
@@ -1,0 +1,48 @@
+use cfg_if::cfg_if;
+
+// Test cases drawn from Solid Router
+// see https://github.com/solidjs/solid-router/blob/main/test/utils.spec.ts
+
+cfg_if! {
+    if #[cfg(not(any(feature = "csr", feature = "hydrate")))] {
+        use leptos_router::join_paths;
+
+        #[test]
+        fn join_paths_should_join_with_a_single_slash() {
+            assert_eq!(join_paths("/foo", "bar"), "/foo/bar");
+            assert_eq!(join_paths("/foo/", "bar"), "/foo/bar");
+            assert_eq!(join_paths("/foo", "/bar"), "/foo/bar");
+            assert_eq!(join_paths("/foo/", "/bar"), "/foo/bar");
+        }
+
+        #[test]
+        fn join_paths_should_ensure_leading_slash() {
+            assert_eq!(join_paths("/foo", ""), "/foo");
+            assert_eq!(join_paths("foo", ""), "/foo");
+            assert_eq!(join_paths("", "foo"), "/foo");
+            assert_eq!(join_paths("", "/foo"), "/foo");
+            assert_eq!(join_paths("/", "foo"), "/foo");
+            assert_eq!(join_paths("/", "/foo"), "/foo");
+        }
+
+        #[test]
+        fn join_paths_should_strip_tailing_slash_asterisk() {
+            assert_eq!(join_paths("foo/*", ""), "/foo");
+            assert_eq!(join_paths("foo/*", "/"), "/foo");
+            assert_eq!(join_paths("/foo/*all", ""), "/foo");
+            assert_eq!(join_paths("/foo/*", "bar"), "/foo/bar");
+            assert_eq!(join_paths("/foo/*all", "bar"), "/foo/bar");
+            assert_eq!(join_paths("/*", "foo"), "/foo");
+            assert_eq!(join_paths("/*all", "foo"), "/foo");
+            assert_eq!(join_paths("*", "foo"), "/foo");
+        }
+
+        #[test]
+        fn join_paths_should_preserve_parameters() {
+            assert_eq!(join_paths("/foo/:bar", ""), "/foo/:bar");
+            assert_eq!(join_paths("/foo/:bar", "baz"), "/foo/:bar/baz");
+            assert_eq!(join_paths("/foo", ":bar/baz"), "/foo/:bar/baz");
+            assert_eq!(join_paths("", ":bar/baz"), "/:bar/baz");
+        }
+    }
+}

--- a/router/tests/matcher.rs
+++ b/router/tests/matcher.rs
@@ -1,0 +1,96 @@
+use cfg_if::cfg_if;
+
+// Test cases drawn from Solid Router
+// see https://github.com/solidjs/solid-router/blob/main/test/utils.spec.ts
+
+cfg_if! {
+    if #[cfg(not(any(feature = "csr", feature = "hydrate")))] {
+        use leptos_router::{params_map, Matcher, PathMatch};
+
+        #[test]
+        fn create_matcher_should_return_no_params_when_location_matches_exactly() {
+            let matcher = Matcher::new("/foo/bar");
+            let matched = matcher.test("/foo/bar");
+            assert_eq!(
+                matched,
+                Some(PathMatch {
+                    path: "/foo/bar".into(),
+                    params: params_map!()
+                })
+            );
+        }
+
+        #[test]
+        fn create_matcher_should_return_none_when_location_doesnt_match() {
+            let matcher = Matcher::new("/foo/bar");
+            let matched = matcher.test("/foo/baz");
+            assert_eq!(matched, None);
+        }
+
+        #[test]
+        fn create_matcher_should_build_params_collection() {
+            let matcher = Matcher::new("/foo/:id");
+            let matched = matcher.test("/foo/abc-123");
+            assert_eq!(
+                matched,
+                Some(PathMatch {
+                    path: "/foo/abc-123".into(),
+                    params: params_map!(
+                        "id".into() => "abc-123".into()
+                    )
+                })
+            );
+        }
+
+        #[test]
+        fn create_matcher_should_match_past_end_when_ending_in_asterisk() {
+            let matcher = Matcher::new("/foo/bar/*");
+            let matched = matcher.test("/foo/bar/baz");
+            assert_eq!(
+                matched,
+                Some(PathMatch {
+                    path: "/foo/bar".into(),
+                    params: params_map!()
+                })
+            );
+        }
+
+        #[test]
+        fn create_matcher_should_not_match_past_end_when_not_ending_in_asterisk() {
+            let matcher = Matcher::new("/foo/bar");
+            let matched = matcher.test("/foo/bar/baz");
+            assert_eq!(matched, None);
+        }
+
+        #[test]
+        fn create_matcher_should_include_remaining_unmatched_location_as_param_when_ending_in_asterisk_and_name(
+        ) {
+            let matcher = Matcher::new("/foo/bar/*something");
+            let matched = matcher.test("/foo/bar/baz/qux");
+            assert_eq!(
+                matched,
+                Some(PathMatch {
+                    path: "/foo/bar".into(),
+                    params: params_map!(
+                        "something".into() => "baz/qux".into()
+                    )
+                })
+            );
+        }
+
+        #[test]
+        fn create_matcher_should_include_empty_param_when_perfect_match_ends_in_asterisk_and_name() {
+            let matcher = Matcher::new("/foo/bar/*something");
+            let matched = matcher.test("/foo/bar");
+            assert_eq!(
+                matched,
+                Some(PathMatch {
+                    path: "/foo/bar".into(),
+                    params: params_map!(
+                        "something".into() => "".into()
+                    )
+                })
+            );
+        }
+    }
+}

--- a/router/tests/resolve_path.rs
+++ b/router/tests/resolve_path.rs
@@ -1,0 +1,107 @@
+use cfg_if::cfg_if;
+
+// Test cases drawn from Solid Router
+// see https://github.com/solidjs/solid-router/blob/main/test/utils.spec.ts
+
+cfg_if! {
+    if #[cfg(not(any(feature = "csr", feature = "hydrate")))] {
+        use leptos_router::{normalize, resolve_path};
+
+        #[test]
+        fn normalize_query_string_with_opening_slash() {
+            assert_eq!(normalize("/?foo=bar", false), "?foo=bar");
+        }
+
+        #[test]
+        fn resolve_path_should_normalize_base_arg() {
+            assert_eq!(resolve_path("base", "", None), Some("/base".into()));
+        }
+
+        #[test]
+        fn resolve_path_should_normalize_path_arg() {
+            assert_eq!(resolve_path("", "path", None), Some("/path".into()));
+        }
+
+        #[test]
+        fn resolve_path_should_normalize_from_arg() {
+            assert_eq!(resolve_path("", "", Some("from")), Some("/from".into()));
+        }
+
+        #[test]
+        fn resolve_path_should_return_default_when_all_empty() {
+            assert_eq!(resolve_path("", "", None), Some("/".into()));
+        }
+
+        #[test]
+        fn resolve_path_should_resolve_root_against_base_and_ignore_from() {
+            assert_eq!(
+                resolve_path("/base", "/", Some("/base/foo")),
+                Some("/base".into())
+            );
+        }
+
+        #[test]
+        fn resolve_path_should_resolve_rooted_paths_against_base_and_ignore_from() {
+            assert_eq!(
+                resolve_path("/base", "/bar", Some("/base/foo")),
+                Some("/base/bar".into())
+            );
+        }
+
+        #[test]
+        fn resolve_path_should_resolve_empty_path_against_from() {
+            assert_eq!(
+                resolve_path("/base", "", Some("/base/foo")),
+                Some("/base/foo".into())
+            );
+        }
+
+        #[test]
+        fn resolve_path_should_resolve_relative_paths_against_from() {
+            assert_eq!(
+                resolve_path("/base", "bar", Some("/base/foo")),
+                Some("/base/foo/bar".into())
+            );
+        }
+
+        #[test]
+        fn resolve_path_should_prepend_base_if_from_doesnt_start_with_it() {
+            assert_eq!(
+                resolve_path("/base", "bar", Some("/foo")),
+                Some("/base/foo/bar".into())
+            );
+        }
+
+        #[test]
+        fn resolve_path_should_test_start_of_from_against_base_case_insensitive() {
+            assert_eq!(
+                resolve_path("/base", "bar", Some("BASE/foo")),
+                Some("/BASE/foo/bar".into())
+            );
+        }
+
+        #[test]
+        fn resolve_path_should_work_with_rooted_search_and_base() {
+            assert_eq!(
+                resolve_path("/base", "/?foo=bar", Some("/base/page")),
+                Some("/base?foo=bar".into())
+            );
+        }
+
+        #[test]
+        fn resolve_path_should_work_with_rooted_search() {
+            assert_eq!(
+                resolve_path("", "/?foo=bar", None),
+                Some("/?foo=bar".into())
+            );
+        }
+
+        #[test]
+        fn preserve_spaces() {
+            assert_eq!(
+                resolve_path(" foo ", " bar baz ", None),
+                Some("/ foo / bar baz ".into())
+            );
+        }
+    }
+}


### PR DESCRIPTION
At some point in late August/early September I moved the router directory, and accidentally lost the tests.

Is it sad that I'm only now getting around to finding them in git and putting them back in? Yes.

Do they still pass? Also yes.