### PR TITLE
Bump actions/checkout to version@3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
I was looking into the test failures.

I see out of memory errors.

I have seem similar errors in a unrelated project, and the solution was to bump the major version of actions/checkout to 3

This may or may not be the problem here ....