### PR TITLE
added `IntoSignal` and `IntoSignalSetter` helper traits

### DIFF
--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -1,5 +1,21 @@
 use crate::{store_value, Memo, ReadSignal, RwSignal, Scope, StoredValue, UntrackedGettableSignal};
 
+/// Helper trait for converting `Fn() -> T` closures into
+/// [`Signal<T>`].
+pub trait IntoSignal<T>: Sized {
+    /// Consumes `self`, returning a [`Signal<T>`].
+    fn derive_signal(self, cx: Scope) -> Signal<T>;
+}
+
+impl<F, T> IntoSignal<T> for F
+where
+    F: Fn() -> T + 'static,
+{
+    fn derive_signal(self, cx: Scope) -> Signal<T> {
+        Signal::derive(cx, self)
+    }
+}
+
 /// A wrapper for any kind of readable reactive signal: a [ReadSignal](crate::ReadSignal),
 /// [Memo](crate::Memo), [RwSignal](crate::RwSignal), or derived signal closure.
 ///

--- a/leptos_reactive/src/signal_wrappers_write.rs
+++ b/leptos_reactive/src/signal_wrappers_write.rs
@@ -1,5 +1,20 @@
 use crate::{store_value, RwSignal, Scope, StoredValue, WriteSignal};
 
+/// Helper trait for converting `Fn(T)` into [`SignalSetter<T>`].
+pub trait IntoSignalSetter<T>: Sized {
+    /// Consumes `self`, returning [`SignalSetter<T>`].
+    fn mapped_signal_setter(self, cx: Scope) -> SignalSetter<T>;
+}
+
+impl<F, T> IntoSignalSetter<T> for F
+where
+    F: Fn(T) + 'static,
+{
+    fn mapped_signal_setter(self, cx: Scope) -> SignalSetter<T> {
+        SignalSetter::map(cx, self)
+    }
+}
+
 /// A wrapper for any kind of settable reactive signal: a [WriteSignal](crate::WriteSignal),
 /// [RwSignal](crate::RwSignal), or closure that receives a value and sets a signal depending
 /// on it.


### PR DESCRIPTION
I'm not sure what name to give the `IntoSignalSetter` method...I thought that `.mapped_signal_setter()` might be appropriate because we already mapped a signal in the closure, and now just need to convert it to the right type. Lmk if you don't like it!