### PR TITLE
Clippy: Removed stray calls to .clone().

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -358,7 +358,7 @@ where IV: IntoView
 
             let res_options = res_options.0.read().await;
 
-            let (status, mut headers) = (res_options.status.clone(), res_options.headers.clone());
+            let (status, mut headers) = (res_options.status, res_options.headers.clone());
             let status = status.unwrap_or_default();
             
             let complete_stream =

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -180,7 +180,7 @@ pub async fn handle_server_fns(
                                     let res_options_outer = res_options.unwrap().0;
                                     let res_options_inner = res_options_outer.read().await;
                                     let (status, mut res_headers) = (
-                                        res_options_inner.status.clone(),
+                                        res_options_inner.status,
                                         res_options_inner.headers.clone(),
                                     );
 


### PR DESCRIPTION
```
cargo clippy

```

Clippy suggest that these .clone() calls are not needed.

I am not making any performance assertions -  that these calls are on a 'hot' path or anything,

 just suggesting doing less mem-copies is always good.
