### PR TITLE
Minor: Clippy format!() all variables now inlined.

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -290,7 +290,7 @@ where IV: IntoView
                 // the site was built with cargo run and not cargo-leptos
                 let bundle_path = match site_root.as_ref() {
                     "pkg" => "pkg".to_string(),
-                    _ => format!("{}/{}", site_root, pkg_path),
+                    _ => format!("{site_root}/{pkg_path}"),
                 };
              
                 let leptos_autoreload = match std::env::var("LEPTOS_WATCH").is_ok() {

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -139,7 +139,7 @@ pub async fn handle_server_fns(
     req: Request<Body>,
 ) -> impl IntoResponse {
     // Axum Path extractor doesn't remove the first slash from the path, while Actix does
-    let fn_name: String = match fn_name.strip_prefix("/") {
+    let fn_name: String = match fn_name.strip_prefix('/') {
         Some(path) => path.to_string(),
         None => fn_name,
     };
@@ -237,9 +237,9 @@ pub async fn handle_server_fns(
                             Response::builder()
                                 .status(StatusCode::BAD_REQUEST)
                                 .body(Full::from(
-                                    format!("Could not find a server function at the route {:?}. \
+                                    format!("Could not find a server function at the route {fn_name}. \
                                     \n\nIt's likely that you need to call ServerFn::register() on the \
-                                    server function type, somewhere in your `main` function.", fn_name)
+                                    server function type, somewhere in your `main` function." )
                                 ))
                         }
                         .expect("could not build Response");
@@ -339,7 +339,7 @@ where
                 // the site was built with cargo run and not cargo-leptos
                 let bundle_path = match site_root.as_ref() {
                     "pkg" => "pkg".to_string(),
-                    _ => format!("{}/{}", site_root, pkg_path),
+                    _ => format!("{site_root}/{pkg_path}"),
                 };
 
                 let output_name = &options.output_name;

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -119,8 +119,7 @@ impl TryFrom<String> for Env {
             "prod" => Ok(Self::PROD),
             "production" => Ok(Self::PROD),
             other => Err(format!(
-                "{} is not a supported environment. Use either `dev` or `production`.",
-                other
+                "{other} is not a supported environment. Use either `dev` or `production`."
             )),
         }
     }

--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -683,9 +683,9 @@ impl<El: ElementDescriptor> IntoView for HtmlElement<El> {
       let children = children;
 
       if attrs.iter_mut().any(|(name, _)| name == "id") {
-        attrs.push(("leptos-hk".into(), format!("_{}", id).into()));
+        attrs.push(("leptos-hk".into(), format!("_{id}").into()));
       } else {
-        attrs.push(("id".into(), format!("_{}", id).into()));
+        attrs.push(("id".into(), format!("_{id}").into()));
       }
 
       element.attrs = attrs;

--- a/leptos_dom/src/logging.rs
+++ b/leptos_dom/src/logging.rs
@@ -45,7 +45,7 @@ macro_rules! debug_warn {
 /// or via `println!()` (if not in the browser).
 pub fn console_log(s: &str) {
   if is_server() {
-    println!("{}", s);
+    println!("{s}");
   } else {
     web_sys::console::log_1(&JsValue::from_str(s));
   }
@@ -55,7 +55,7 @@ pub fn console_log(s: &str) {
 /// or via `println!()` (if not in the browser).
 pub fn console_warn(s: &str) {
   if is_server() {
-    eprintln!("{}", s);
+    eprintln!("{s}");
   } else {
     web_sys::console::warn_1(&JsValue::from_str(s));
   }
@@ -65,7 +65,7 @@ pub fn console_warn(s: &str) {
 /// or via `println!()` (if not in the browser).
 pub fn console_error(s: &str) {
   if is_server() {
-    eprintln!("{}", s);
+    eprintln!("{s}");
   } else {
     web_sys::console::warn_1(&JsValue::from_str(s));
   }
@@ -77,7 +77,7 @@ pub fn console_debug_warn(s: &str) {
   cfg_if! {
       if #[cfg(debug_assertions)] {
           if is_server() {
-              eprintln!("{}", s);
+              eprintln!("{s}");
           } else {
               web_sys::console::warn_1(&JsValue::from_str(s));
           }

--- a/leptos_macro/src/props.rs
+++ b/leptos_macro/src/props.rs
@@ -105,11 +105,11 @@ mod struct_info {
                 builder_attr,
                 builder_name: syn::Ident::new(&builder_name, proc_macro2::Span::call_site()),
                 conversion_helper_trait_name: syn::Ident::new(
-                    &format!("{}_Optional", builder_name),
+                    &format!("{builder_name}_Optional"),
                     proc_macro2::Span::call_site(),
                 ),
                 core: syn::Ident::new(
-                    &format!("{}_core", builder_name),
+                    &format!("{builder_name}_core"),
                     proc_macro2::Span::call_site(),
                 ),
             })
@@ -391,7 +391,7 @@ mod struct_info {
                 ),
                 proc_macro2::Span::call_site(),
             );
-            let repeated_fields_error_message = format!("Repeated field {}", field_name);
+            let repeated_fields_error_message = format!("Repeated field {field_name}");
 
             Ok(quote! {
                 #[allow(dead_code, non_camel_case_types, missing_docs)]
@@ -513,7 +513,7 @@ mod struct_info {
                 ),
                 proc_macro2::Span::call_site(),
             );
-            let early_build_error_message = format!("Missing required field {}", field_name);
+            let early_build_error_message = format!("Missing required field {field_name}");
 
             Ok(quote! {
                 #[doc(hidden)]
@@ -622,7 +622,7 @@ mod struct_info {
                         // I'd prefer “a” or “an” to “its”, but determining which is grammatically
                         // correct is roughly impossible.
                         let doc =
-                            format!("Finalise the builder and create its [`{}`] instance", name);
+                            format!("Finalise the builder and create its [`{name}`] instance");
                         quote!(#[doc = #doc])
                     }
                 }
@@ -718,7 +718,7 @@ mod struct_info {
                         }
                         _ => Err(Error::new_spanned(
                             &assign,
-                            format!("Unknown parameter {:?}", name),
+                            format!("Unknown parameter {name:?}"),
                         )),
                     }
                 }
@@ -732,7 +732,7 @@ mod struct_info {
                         }
                         _ => Err(Error::new_spanned(
                             &path,
-                            format!("Unknown parameter {:?}", name),
+                            format!("Unknown parameter {name:?}"),
                         )),
                     }
                 }
@@ -747,7 +747,7 @@ mod struct_info {
                         let call_func = quote!(#call_func);
                         Error::new_spanned(
                             &call.func,
-                            format!("Illegal builder setting group {}", call_func),
+                            format!("Illegal builder setting group {call_func}"),
                         )
                     })?;
                     match subsetting_name.as_str() {
@@ -759,7 +759,7 @@ mod struct_info {
                         }
                         _ => Err(Error::new_spanned(
                             &call.func,
-                            format!("Illegal builder setting group name {}", subsetting_name),
+                            format!("Illegal builder setting group name {subsetting_name}"),
                         )),
                     }
                 }
@@ -924,7 +924,7 @@ mod field_info {
                                 let tokenized_code = TokenStream::from_str(&code.value())?;
                                 self.default = Some(
                                     syn::parse(tokenized_code.into())
-                                        .map_err(|e| Error::new_spanned(code, format!("{}", e)))?,
+                                        .map_err(|e| Error::new_spanned(code, format!("{e}")))?,
                                 );
                             } else {
                                 return Err(Error::new_spanned(assign.right, "Expected string"));
@@ -933,7 +933,7 @@ mod field_info {
                         }
                         _ => Err(Error::new_spanned(
                             &assign,
-                            format!("Unknown parameter {:?}", name),
+                            format!("Unknown parameter {name:?}"),
                         )),
                     }
                 }
@@ -950,7 +950,7 @@ mod field_info {
                         }
                         _ => Err(Error::new_spanned(
                             &path,
-                            format!("Unknown parameter {:?}", name),
+                            format!("Unknown parameter {name:?}"),
                         )),
                     }
                 }
@@ -965,7 +965,7 @@ mod field_info {
                         let call_func = quote!(#call_func);
                         Error::new_spanned(
                             &call.func,
-                            format!("Illegal builder setting group {}", call_func),
+                            format!("Illegal builder setting group {call_func}"),
                         )
                     })?;
                     match subsetting_name.as_ref() {
@@ -977,7 +977,7 @@ mod field_info {
                         }
                         _ => Err(Error::new_spanned(
                             &call.func,
-                            format!("Illegal builder setting group name {}", subsetting_name),
+                            format!("Illegal builder setting group name {subsetting_name}"),
                         )),
                     }
                 }
@@ -1047,7 +1047,7 @@ mod field_info {
                         }
                         _ => Err(Error::new_spanned(
                             &assign,
-                            format!("Unknown parameter {:?}", name),
+                            format!("Unknown parameter {name:?}"),
                         )),
                     }
                 }

--- a/leptos_macro/src/server.rs
+++ b/leptos_macro/src/server.rs
@@ -47,7 +47,7 @@ pub fn server_macro_impl(args: proc_macro::TokenStream, s: TokenStream2) -> Resu
             use proc_macro::Span;
             let span = Span::call_site();
             #[cfg(not(target_os = "windows"))]
-            let url = format!("{}/{}", span.source_file().path().to_string_lossy(), fn_name_as_str).replace("/", "-");
+            let url = format!("{}/{}", span.source_file().path().to_string_lossy(), fn_name_as_str).replace('/', "-");
             #[cfg(target_os = "windows")]
             let url = format!("{}/{}", span.source_file().path().to_string_lossy(), fn_name_as_str).replace("\\", "-");
         } else {

--- a/leptos_reactive/src/effect.rs
+++ b/leptos_reactive/src/effect.rs
@@ -172,7 +172,7 @@ where
             level = "debug",
             skip_all,
             fields(
-                id = %format!("{:?}", id),
+                id = %format!("{id:?}"),
                 defined_at = %format!("{:?}", self.defined_at),
                 ty = %std::any::type_name::<T>()
             )
@@ -220,7 +220,7 @@ impl EffectId {
             level = "debug",
             skip_all,
             fields(
-                id = %format!("{:?}", self),
+                id = %format!("{self:?}"),
             )
         )
     )]

--- a/router/src/history/params.rs
+++ b/router/src/history/params.rs
@@ -118,7 +118,7 @@ where
             Some(value) => match T::from_str(value) {
                 Ok(value) => Ok(Some(value)),
                 Err(e) => {
-                    eprintln!("{}", e);
+                    eprintln!("{e}");
                     Err(ParamsError::Params(Rc::new(e)))
                 }
             },


### PR DESCRIPTION
Here is link the clippy discussion

https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

lots of changes of the form

```
-        _ => format!("{}/{}", site_root, pkg_path),
+        _ => format!("{site_root}/{pkg_path}"),
```

To me this is a very minor readability change... 
The real advantage is that things  I feel strongly about are often lost in the noise of a large list.

When a more pressing problem occurs ... I want to see it.