### PR TITLE
Removing clone call where possible(round2).

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -97,7 +97,7 @@ pub async fn generate_request_parts(req: Request<Body>) -> RequestParts {
         uri: parts.uri,
         headers: parts.headers,
         version: parts.version,
-        body: body.clone(),
+        body,
     }
 }
 

--- a/leptos_dom/src/components.rs
+++ b/leptos_dom/src/components.rs
@@ -243,7 +243,7 @@ where
       children_fn,
     } = self;
 
-    let mut repr = ComponentRepr::new_with_id(name.clone(), id);
+    let mut repr = ComponentRepr::new_with_id(name, id);
 
     // disposed automatically when the parent scope is disposed
     let (child, _) =


### PR DESCRIPTION
Sorry for the noise, 

It seems with all these minor changes we have changed the way chippy perceives the code-base
(Earlier today I found only 2 places where .clone() was called without reason.)

Now under iteration I see a  few more places, so this is round two.

