### PR TITLE
Clippy: Minor needless_borrowed_reference.

### DIFF
--- a/leptos_macro/src/props.rs
+++ b/leptos_macro/src/props.rs
@@ -282,7 +282,7 @@ mod struct_info {
             });
             let reconstructing = self.included_fields().map(|f| f.name);
 
-            let &FieldInfo {
+            let FieldInfo {
                 name: ref field_name,
                 ty: ref field_type,
                 ..


### PR DESCRIPTION
This is a minor chippy warning 

Here is the link to the clippy issue page.

https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrowed_reference

