### PR TITLE
Adjust default features for `meta` and `router`

### DIFF
--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 console_log = "0.2"
 log = "0.4"
 leptos = { path = "../../leptos" }
-leptos_router = { path = "../../router", features=["csr"] }
+leptos_router = { path = "../../router", features = ["csr"] }
 serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 console_error_panic_hook = "0.1.7"
-leptos_meta = { path = "../../meta", default-features = false }
+leptos_meta = { path = "../../meta", features = ["csr"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.3"
 features = ["HtmlLinkElement", "HtmlMetaElement", "HtmlTitleElement"]
 
 [features]
-default = ["csr"]
+default = []
 csr = ["leptos/csr", "leptos/tracing"]
 hydrate = ["leptos/hydrate", "leptos/tracing"]
 ssr = ["leptos/ssr", "leptos/tracing"]

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -53,7 +53,7 @@ features = [
 ]
 
 [features]
-default = ["csr"]
+default = []
 csr = ["leptos/csr"]
 hydrate = ["leptos/hydrate"]
 ssr = ["leptos/ssr", "dep:url", "dep:regex"]


### PR DESCRIPTION
Fixes an issue in which `leptos_meta` and `leptos_router` tried to erroneously use browser APIs on the server side, possibly after recent changes to workspace structure.