### PR TITLE
Generate Routes and pass them to Actix/Axum

### DIFF
--- a/examples/todo_app_sqlite/src/main.rs
+++ b/examples/todo_app_sqlite/src/main.rs
@@ -31,7 +31,7 @@ cfg_if! {
             let addr = conf.leptos_options.site_address.clone();
             println!("BEFFOORE");
             let routes = generate_route_list(|cx| view! { cx, <TodoApp/> });
-            println!("HIIIIIIIIIIII");
+
             println!("Routes: {:#?}", routes);
 
             HttpServer::new(move || {

--- a/examples/todo_app_sqlite/src/main.rs
+++ b/examples/todo_app_sqlite/src/main.rs
@@ -1,5 +1,6 @@
 use cfg_if::cfg_if;
 use leptos::*;
+use leptos_router::generate_route_list;
 mod todo;
 
 // boilerplate to run in different modes
@@ -28,6 +29,10 @@ cfg_if! {
 
             let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
             let addr = conf.leptos_options.site_address.clone();
+            println!("BEFFOORE");
+            let routes = generate_route_list(|cx| view! { cx, <TodoApp/> });
+            println!("HIIIIIIIIIIII");
+            println!("Routes: {:#?}", routes);
 
             HttpServer::new(move || {
                 let leptos_options = &conf.leptos_options;

--- a/examples/todo_app_sqlite/src/todo.rs
+++ b/examples/todo_app_sqlite/src/todo.rs
@@ -38,9 +38,11 @@ cfg_if! {
 pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
     // this is just an example of how to access server context injected in the handlers
     let req =
-        use_context::<actix_web::HttpRequest>(cx).expect("couldn't get HttpRequest from context");
-    println!("req.path = {:?}", req.path());
-
+        use_context::<actix_web::HttpRequest>(cx);
+    
+    if let Some(req) = req{
+    println!("req.path = {:#?}", req.path());
+    }
     use futures::TryStreamExt;
 
     let mut conn = db().await?;
@@ -100,6 +102,10 @@ pub fn TodoApp(cx: Scope) -> impl IntoView {
             <main>
                 <Routes>
                     <Route path="" view=|cx| view! {
+                        cx,
+                        <Todos/>
+                    }/>
+                    <Route path="potato" view=|cx| view! {
                         cx,
                         <Todos/>
                     }/>

--- a/examples/todo_app_sqlite/src/todo.rs
+++ b/examples/todo_app_sqlite/src/todo.rs
@@ -92,6 +92,7 @@ pub async fn delete_todo(id: u16) -> Result<(), ServerFnError> {
 
 #[component]
 pub fn TodoApp(cx: Scope) -> impl IntoView {
+    provide_meta_context(cx);
     view! {
         cx,
         <Stylesheet id="leptos" href="./target/site/pkg/todo_app_sqlite.css"/>

--- a/examples/todo_app_sqlite/src/todo.rs
+++ b/examples/todo_app_sqlite/src/todo.rs
@@ -95,7 +95,7 @@ pub fn TodoApp(cx: Scope) -> impl IntoView {
     provide_meta_context(cx);
     view! {
         cx,
-        <Stylesheet id="leptos" href="./target/site/pkg/todo_app_sqlite.css"/>
+        <Stylesheet id="leptos" href="/pkg/todo_app_sqlite.css"/>
         <Router>
             <header>
                 <h1>"My Tasks"</h1>

--- a/examples/todo_app_sqlite_axum/src/todo.rs
+++ b/examples/todo_app_sqlite_axum/src/todo.rs
@@ -39,9 +39,11 @@ cfg_if! {
 pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
     // this is just an example of how to access server context injected in the handlers
     // http::Request doesn't implement Clone, so more work will be needed to do use_context() on this
-    let req_parts = use_context::<leptos_axum::RequestParts>(cx).unwrap();
-    println!("\ncalling server fn");
+    let req_parts = use_context::<leptos_axum::RequestParts>(cx);
+    
+    if let Some(req_parts) = req_parts{
     println!("Uri = {:?}", req_parts.uri);
+    }
 
     use futures::TryStreamExt;
 
@@ -105,6 +107,7 @@ pub async fn delete_todo(id: u16) -> Result<(), ServerFnError> {
 
 #[component]
 pub fn TodoApp(cx: Scope) -> impl IntoView {
+    provide_meta_context(cx);
     view! {
         cx,
         <Stylesheet id="leptos" href="./target/site/pkg/todo_app_sqlite_axum.css"/>

--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -19,4 +19,5 @@ leptos_meta = { path = "../../meta", default-features = false, version = "0.1.0-
 leptos_router = { path = "../../router", default-features = false, version = "0.1.0-alpha", features = [
 	"ssr",
 ] }
+regex = "1.7.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -531,7 +531,15 @@ where
 
     let routes = routes.0.read().await.to_owned();
     // Axum's Router defines Root routes as "/" not ""
-    routes.iter().map(|s| s.replace("", "/")).collect()
+    routes
+        .iter()
+        .map(|s| {
+            if s.is_empty() {
+                return "/".to_string();
+            }
+            s.to_string()
+        })
+        .collect()
 }
 
 /// This trait allows one to pass a list of routes and a render function to Axum's router, letting us avoid

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -11,8 +11,8 @@ use wasm_bindgen::JsCast;
 use leptos_reactive::use_transition;
 
 use crate::{
-    create_location, matching::resolve_path, History, Location, LocationChange, RouteContext,
-    RouterIntegrationContext, State,
+    create_location, matching::resolve_path, Branch, History, Location, LocationChange,
+    RouteContext, RouterIntegrationContext, State,
 };
 
 #[cfg(not(feature = "ssr"))]
@@ -49,6 +49,7 @@ pub struct RouterContext {
 pub(crate) struct RouterContextInner {
     pub location: Location,
     pub base: RouteContext,
+    pub possible_routes: RefCell<Option<Vec<Branch>>>,
     base_path: String,
     history: Box<dyn History>,
     cx: Scope,
@@ -104,10 +105,10 @@ impl RouterContext {
                     value: base_path.to_string(),
                     replace: true,
                     scroll: false,
-                    state: State(None)
+                    state: State(None),
                 });
             }
-		}
+        }
 
         // the current URL
         let (reference, set_reference) = create_signal(cx, source.with(|s| s.value.clone()));
@@ -153,6 +154,7 @@ impl RouterContext {
             referrers,
             state,
             set_state,
+            possible_routes: Default::default(),
         });
 
         // handle all click events on anchor tags
@@ -174,6 +176,15 @@ impl RouterContext {
     /// The [RouteContext] of the base route.
     pub fn base(&self) -> RouteContext {
         self.inner.base.clone()
+    }
+
+    /// A list of all possible routes this router can match.
+    pub fn possible_branches(&self) -> Vec<Branch> {
+        self.inner
+            .possible_routes
+            .borrow()
+            .clone()
+            .unwrap_or_default()
     }
 }
 

--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -12,7 +12,7 @@ use crate::{
         expand_optionals, get_route_matches, join_paths, Branch, Matcher, RouteDefinition,
         RouteMatch,
     },
-    RouteContext, RouterContext,
+    PossibleBranchContext, RouteContext, RouterContext,
 };
 
 /// Contains route definitions and manages the actual routing process.
@@ -42,12 +42,17 @@ pub fn Routes(
         })
         .cloned()
         .collect::<Vec<_>>();
+
     create_branches(
         &children,
         &base.unwrap_or_default(),
         &mut Vec::new(),
         &mut branches,
     );
+
+    if let Some(context) = use_context::<PossibleBranchContext>(cx) {
+        *context.0.borrow_mut() = branches.clone();
+    }
 
     // whenever path changes, update matches
     let matches = create_memo(cx, {

--- a/router/src/extract_routes.rs
+++ b/router/src/extract_routes.rs
@@ -9,7 +9,7 @@ pub struct PossibleBranchContext(pub(crate) Rc<RefCell<Vec<Branch>>>);
 
 /// Generates a list of all routes this application could possibly serve.
 #[cfg(feature = "ssr")]
-pub fn generate_route_list<IV>(app_fn: impl FnOnce(Scope) -> IV + 'static) -> Vec<String>
+pub fn generate_route_list_inner<IV>(app_fn: impl FnOnce(Scope) -> IV + 'static) -> Vec<String>
 where
     IV: IntoView + 'static,
 {

--- a/router/src/extract_routes.rs
+++ b/router/src/extract_routes.rs
@@ -1,0 +1,34 @@
+use leptos::*;
+use std::{cell::RefCell, rc::Rc};
+
+use crate::{Branch, RouterIntegrationContext, ServerIntegration};
+
+/// Context to contain all possible routes.
+#[derive(Clone, Default, Debug)]
+pub struct PossibleBranchContext(pub(crate) Rc<RefCell<Vec<Branch>>>);
+
+/// Generates a list of all routes this application could possibly serve.
+#[cfg(feature = "ssr")]
+pub fn generate_route_list<IV>(app_fn: impl FnOnce(Scope) -> IV + 'static) -> Vec<String>
+where
+    IV: IntoView + 'static,
+{
+    let runtime = create_runtime();
+    run_scope(runtime, move |cx| {
+        let integration = ServerIntegration {
+            path: "http://leptos.rs/".to_string(),
+        };
+
+        provide_context(cx, RouterIntegrationContext::new(integration));
+        let branches = PossibleBranchContext::default();
+        provide_context(cx, branches.clone());
+
+        let _ = app_fn(cx).into_view(cx);
+
+        let branches = branches.0.borrow();
+        branches
+            .iter()
+            .flat_map(|branch| branch.routes.last().map(|route| route.pattern.clone()))
+            .collect()
+    })
+}

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -184,12 +184,14 @@
 #![cfg_attr(not(feature = "stable"), feature(type_name_of_val))]
 
 mod components;
+mod extract_routes;
 mod history;
 mod hooks;
 #[doc(hidden)]
 pub mod matching;
 
 pub use components::*;
+pub use extract_routes::*;
 pub use history::*;
 pub use hooks::*;
 pub use matching::*;


### PR DESCRIPTION
This PR provides a function to walk the Leptos router's app tree and produce a list of routes. Each integration has conversions to parse them into a format for either Actix or Axum, and then a trait to provide a `.leptos_routes()` extension for their respective routers.

This lets us avoid any wildcard routes for routing leptos! And allows you to define routes in only one place! We can do some server side error handling, and be a better neighbor for other services.

I also put in the changes from #241 which are simplified by this change. Take a look and let me know if you spot any issues. The Actix version especially needs some prodding, it's got some fairly involved regexs, as its pathing is quite different from leptos_router.

The todo_app_sqlite and todo_app_sqlite_axum extensions have been updated to the new format. I'll update the rest if it looks good