### PR TITLE
examples/hackernews - Cargo clippy fixes.

### DIFF
--- a/examples/hackernews/src/main.rs
+++ b/examples/hackernews/src/main.rs
@@ -1,5 +1,4 @@
 use cfg_if::cfg_if;
-use leptos::*;
 
 // boilerplate to run in different modes
 cfg_if! {

--- a/examples/hackernews/src/main.rs
+++ b/examples/hackernews/src/main.rs
@@ -1,4 +1,5 @@
 use cfg_if::cfg_if;
+use leptos::*;
 
 // boilerplate to run in different modes
 cfg_if! {

--- a/examples/hackernews/src/routes/stories.rs
+++ b/examples/hackernews/src/routes/stories.rs
@@ -48,12 +48,12 @@ pub fn Stories(cx: Scope) -> impl IntoView {
                     {move || if page() > 1 {
                         view! {
                             cx,
-                            <a class="page-link"
+                            <html::a class="page-link"
                                 href=move || format!("/{}?page={}", story_type(), page() - 1)
                                 attr:aria_label="Previous Page"
                             >
                                 "< prev"
-                            </a>
+                            </html::a>
                         }.into_any()
                     } else {
                         view! {
@@ -134,7 +134,7 @@ fn Story(cx: Scope, story: api::Story) -> impl IntoView {
                     view! { cx,
                         <span>
                             {"by "}
-                            {story.user.map(|user| view ! { cx, <A href=format!("/users/{}", user)>{user.clone()}</A>})}
+                            {story.user.map(|user| view ! { cx, <A href=format!("/users/{user}")>{user.clone()}</A>})}
                             {format!(" {} | ", story.time_ago)}
                             <A href=format!("/stories/{}", story.id)>
                                 {if story.comments_count.unwrap_or_default() > 0 {

--- a/examples/hackernews/src/routes/story.rs
+++ b/examples/hackernews/src/routes/story.rs
@@ -17,7 +17,7 @@ pub fn Story(cx: Scope) -> impl IntoView {
             }
         },
     );
-    let meta_description = move || story.read().and_then(|story| story.map(|story| story.title.clone())).unwrap_or_else(|| "Loading story...".to_string());
+    let meta_description = move || story.read().and_then(|story| story.map(|story| story.title)).unwrap_or_else(|| "Loading story...".to_string());
 
     view! { cx,
         <>
@@ -37,7 +37,7 @@ pub fn Story(cx: Scope) -> impl IntoView {
                                 {story.user.map(|user| view! { cx,  <p class="meta">
                                     {story.points}
                                     " points | by "
-                                    <A href=format!("/users/{}", user)>{user.clone()}</A>
+                                    <A href=format!("/users/{user}")>{user.clone()}</A>
                                     {format!(" {}", story.time_ago)}
                                 </p>})}
                                 </div>

--- a/leptos_macro/src/props.rs
+++ b/leptos_macro/src/props.rs
@@ -188,8 +188,7 @@ mod struct_info {
                     Some(ref doc) => quote!(#[doc = #doc]),
                     None => {
                         let doc = format!(
-                        "Builder for [`{name}`] instances.\n\nSee [`{name}::builder()`] for more info.",
-                        name = name
+                        "Builder for [`{name}`] instances.\n\nSee [`{name}::builder()`] for more info."
                     );
                         quote!(#[doc = #doc])
                     }


### PR DESCRIPTION
Previously I  have been sweeping up errors by running cargo clippy from the root directory.

Today I ran  "cargo clippy" from examples/hackernews.

The feature flags in this example change the build environment

running  "cargo clippy" here picks up a few more issues.

I WAS trying to fix issues class-by-class, but in this PR there are previously visited rules : -

Redundant clone issues.
clippy::uninlined_format_args

I hope that explains why some of these rules are re-appearing

Here is the clippy warning for a new ambiguous namespace issue found in the view macro

```
warning: `leptos_router` (lib) generated 3 warnings (run `cargo clippy --fix --lib -p leptos_router` to apply 3 suggestions)
    Checking hackernews v0.1.0 (/home/martin/build/leptos/examples/hackernews)
warning: The view macro is assuming this is an HTML element, but it is ambiguous; if it is an SVG or MathML element, prefix with svg:: or math::
  --> src/routes/stories.rs:51:30
   |
51 | ...                   <a class="page-link"
```