### PR TITLE
Minor: Clippy fixes related to hackernew_axum.

### DIFF
--- a/examples/hackernews_axum/src/routes/stories.rs
+++ b/examples/hackernews_axum/src/routes/stories.rs
@@ -48,12 +48,12 @@ pub fn Stories(cx: Scope) -> impl IntoView {
                     {move || if page() > 1 {
                         view! {
                             cx,
-                            <a class="page-link"
+                            <html::a class="page-link"
                                 href=move || format!("/{}?page={}", story_type(), page() - 1)
                                 attr:aria_label="Previous Page"
                             >
                                 "< prev"
-                            </a>
+                            </html::a>
                         }.into_any()
                     } else {
                         view! {
@@ -134,7 +134,7 @@ fn Story(cx: Scope, story: api::Story) -> impl IntoView {
                     view! { cx,
                         <span>
                             {"by "}
-                            {story.user.map(|user| view ! { cx, <A href=format!("/users/{}", user)>{user.clone()}</A>})}
+                            {story.user.map(|user| view ! { cx, <A href=format!("/users/{user}")>{user.clone()}</A>})}
                             {format!(" {} | ", story.time_ago)}
                             <A href=format!("/stories/{}", story.id)>
                                 {if story.comments_count.unwrap_or_default() > 0 {

--- a/examples/hackernews_axum/src/routes/story.rs
+++ b/examples/hackernews_axum/src/routes/story.rs
@@ -17,7 +17,7 @@ pub fn Story(cx: Scope) -> impl IntoView {
             }
         },
     );
-    let meta_description = move || story.read().and_then(|story| story.map(|story| story.title.clone())).unwrap_or_else(|| "Loading story...".to_string());
+    let meta_description = move || story.read().and_then(|story| story.map(|story| story.title)).unwrap_or_else(|| "Loading story...".to_string());
 
     view! { cx,
         <>
@@ -37,7 +37,7 @@ pub fn Story(cx: Scope) -> impl IntoView {
                                 {story.user.map(|user| view! { cx,  <p class="meta">
                                     {story.points}
                                     " points | by "
-                                    <A href=format!("/users/{}", user)>{user.clone()}</A>
+                                    <A href=format!("/users/{user}")>{user.clone()}</A>
                                     {format!(" {}", story.time_ago)}
                                 </p>})}
                                 </div>


### PR DESCRIPTION
This is similar to recent fixes related to examples/hackernews

examples/hackernews_axum changes the build flags in a way that is distinct and so exposed different clippy warning 

in short 

1) A couple of .clone() call are removed
2) more inline formatting.
3) namespace disambiguation  <html::a class="page-link">
