### PR TITLE
Improve test reliability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ leptos_server = { path = "./leptos_server", default-features = false, version = 
 leptos_config = { path = "./leptos_config", default-features = false, version = "0.1.0-beta" }
 leptos_router = { path = "./router", version = "0.1.0-beta" }
 leptos_meta = { path = "./meta", default-feature = false, version = "0.1.0-beta" }
+simple_logger = "4.0.0"
 
 [profile.release]
 codegen-units = 1

--- a/examples/counter_isomorphic/Cargo.toml
+++ b/examples/counter_isomorphic/Cargo.toml
@@ -23,7 +23,7 @@ leptos_actix = { path = "../../integrations/actix", optional = true }
 leptos_meta = { path = "../../meta", default-features = false }
 leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
-simple_logger = "2"
+simple_logger = { workspace = true }
 gloo-net = { git = "https://github.com/rustwasm/gloo" }
 
 [features]

--- a/examples/hackernews/Cargo.toml
+++ b/examples/hackernews/Cargo.toml
@@ -14,12 +14,14 @@ console_log = "0.2"
 console_error_panic_hook = "0.1"
 futures = "0.3"
 cfg-if = "1"
-leptos = { path = "../../leptos", default-features = false, features = ["serde"] }
+leptos = { path = "../../leptos", default-features = false, features = [
+	"serde",
+] }
 leptos_meta = { path = "../../meta", default-features = false }
 leptos_actix = { path = "../../integrations/actix", default-features = false, optional = true }
 leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
-simple_logger = "2"
+simple_logger = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 gloo-net = { version = "0.2", features = ["http"] }
@@ -47,26 +49,26 @@ skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
-output-name = "hackernews"	
+output-name = "hackernews"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written
 # Defaults to pkg	
-site-pkg-dir = "pkg" 	
+site-pkg-dir = "pkg"
 # [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
 style-file = "./style.css"
 # [Optional] Files in the asset-dir will be copied to the site-root directory
 # assets-dir = "static/assets"
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-address = "127.0.0.1:3000"	
+site-address = "127.0.0.1:3000"
 # The port to use for automatic reload monitoring
-reload-port = 3001	
+reload-port = 3001
 # [Optional] Command to use when running end2end tests. It will run in the end2end dir.
 end2end-cmd = "npx playwright test"
 #  The browserlist query used for optimizing the CSS.
-browserquery = "defaults" 	
+browserquery = "defaults"
 # Set by cargo-leptos watch when building with tha tool. Controls whether autoreload JS will be included in the head
-watch = false 	
+watch = false
 # The environment Leptos will run in, usually either "DEV" or "PROD"
 env = "DEV"
 # The features to use when compiling the bin target

--- a/examples/hackernews_axum/Cargo.toml
+++ b/examples/hackernews_axum/Cargo.toml
@@ -19,7 +19,7 @@ leptos_axum = { path = "../../integrations/axum", optional = true }
 leptos_meta = { path = "../../meta", default-features = false }
 leptos_router = { path = "../../router", default-features = false }
 log = "0.4.17"
-simple_logger = "4.0.0"
+simple_logger = { workspace = true }
 serde = { version = "1.0.148", features = ["derive"] }
 serde_json = "1.0.89"
 gloo-net = { version = "0.2.5", features = ["http"] }
@@ -55,26 +55,26 @@ skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
-output-name = "hackernews_axum"	
+output-name = "hackernews_axum"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written
 # Defaults to pkg	
-site-pkg-dir = "pkg" 	
+site-pkg-dir = "pkg"
 # [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
 style-file = "./style.css"
 # [Optional] Files in the asset-dir will be copied to the site-root directory
 # assets-dir = "static/assets"
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-address = "127.0.0.1:3000"	
+site-address = "127.0.0.1:3000"
 # The port to use for automatic reload monitoring
-reload-port = 3001	
+reload-port = 3001
 # [Optional] Command to use when running end2end tests. It will run in the end2end dir.
 end2end-cmd = "npx playwright test"
 #  The browserlist query used for optimizing the CSS.
-browserquery = "defaults" 	
+browserquery = "defaults"
 # Set by cargo-leptos watch when building with tha tool. Controls whether autoreload JS will be included in the head
-watch = false 	
+watch = false
 # The environment Leptos will run in, usually either "DEV" or "PROD"
 env = "DEV"
 # The features to use when compiling the bin target

--- a/examples/todo_app_sqlite/Cargo.toml
+++ b/examples/todo_app_sqlite/Cargo.toml
@@ -8,7 +8,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 actix-files = { version = "0.6.2", optional = true }
-actix-web = { version = "4.2.1", optional = true, features = ["openssl", "macros"] }
+actix-web = { version = "4.2.1", optional = true, features = [
+	"openssl",
+	"macros",
+] }
 anyhow = "1.0.68"
 broadcaster = "1.0.0"
 console_log = "0.2.0"
@@ -23,7 +26,7 @@ leptos_actix = { path = "../../integrations/actix", optional = true }
 leptos_meta = { path = "../../meta", default-features = false }
 leptos_router = { path = "../../router", default-features = false }
 log = "0.4.17"
-simple_logger = "4.0.0"
+simple_logger = { workspace = true }
 gloo = { git = "https://github.com/rustwasm/gloo" }
 sqlx = { version = "0.6.2", features = [
 	"runtime-tokio-rustls",
@@ -49,26 +52,26 @@ skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
-output-name = "todo_app_sqlite"	
+output-name = "todo_app_sqlite"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written
 # Defaults to pkg	
-site-pkg-dir = "pkg" 	
+site-pkg-dir = "pkg"
 # [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
 style-file = "./style.css"
 # [Optional] Files in the asset-dir will be copied to the site-root directory
 # assets-dir = "static/assets"
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-address = "127.0.0.1:3000"	
+site-address = "127.0.0.1:3000"
 # The port to use for automatic reload monitoring
-reload-port = 3001	
+reload-port = 3001
 # [Optional] Command to use when running end2end tests. It will run in the end2end dir.
 end2end-cmd = "npx playwright test"
 #  The browserlist query used for optimizing the CSS.
-browserquery = "defaults" 	
+browserquery = "defaults"
 # Set by cargo-leptos watch when building with tha tool. Controls whether autoreload JS will be included in the head
-watch = false 	
+watch = false
 # The environment Leptos will run in, usually either "DEV" or "PROD"
 env = "DEV"
 # The features to use when compiling the bin target

--- a/examples/todo_app_sqlite_axum/Cargo.toml
+++ b/examples/todo_app_sqlite_axum/Cargo.toml
@@ -19,7 +19,7 @@ leptos_axum = { path = "../../../leptos/integrations/axum", default-features = f
 leptos_meta = { path = "../../../leptos/meta", default-features = false }
 leptos_router = { path = "../../../leptos/router", default-features = false }
 log = "0.4.17"
-simple_logger = "4.0.0"
+simple_logger = { workspace = true }
 serde = { version = "1.0.148", features = ["derive"] }
 serde_json = "1.0.89"
 gloo-net = { version = "0.2.5", features = ["http"] }
@@ -51,38 +51,31 @@ ssr = [
 ]
 
 [package.metadata.cargo-all-features]
-denylist = [
-	"axum",
-	"tower",
-	"tower-http",
-	"tokio",
-	"sqlx",
-	"leptos_axum",
-]
+denylist = ["axum", "tower", "tower-http", "tokio", "sqlx", "leptos_axum"]
 skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
-output-name = "todo_app_sqlite_axum"	
+output-name = "todo_app_sqlite_axum"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written
 # Defaults to pkg	
-site-pkg-dir = "pkg" 	
+site-pkg-dir = "pkg"
 # [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
 style-file = "./style.css"
 # [Optional] Files in the asset-dir will be copied to the site-root directory
 # assets-dir = "static/assets"
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-address = "127.0.0.1:3000"	
+site-address = "127.0.0.1:3000"
 # The port to use for automatic reload monitoring
-reload-port = 3001	
+reload-port = 3001
 # [Optional] Command to use when running end2end tests. It will run in the end2end dir.
 end2end-cmd = "npx playwright test"
 #  The browserlist query used for optimizing the CSS.
-browserquery = "defaults" 	
+browserquery = "defaults"
 # Set by cargo-leptos watch when building with tha tool. Controls whether autoreload JS will be included in the head
-watch = false 	
+watch = false
 # The environment Leptos will run in, usually either "DEV" or "PROD"
 env = "DEV"
 # The features to use when compiling the bin target


### PR DESCRIPTION
I have been looking at all the recent build failures.

A common problem is a run for about 40 mins and the build exits with "no more disc space" type  errors.

For open source projects the resources allocated are minimal at  best. This is my attempt to slowly sweep away any issues, in the hope that if I can find enough nits, so that the situation improves.

"simple_logger" is used in multiple sub crates - I have moved it up to the root level. In my own projects  I have found this type of activity reduces the server memory footprint and build time.

PS The is also a separate consistency issue, regarding simple_logger -   we were using a  mixture of version 2 and version 4.

