### PR TITLE
Reducing build workload, wasm-bindgen crates moved to root workspace.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ leptos_server = { path = "./leptos_server", default-features = false, version = 
 leptos_config = { path = "./leptos_config", default-features = false, version = "0.1.0-beta" }
 leptos_router = { path = "./router", version = "0.1.0-beta" }
 leptos_meta = { path = "./meta", default-feature = false, version = "0.1.0-beta" }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+wasm-bindgen-test = "0.3.0"
 
 [profile.release]
 codegen-units = 1

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -11,20 +11,15 @@ tokio-test = "0.4"
 miniserde = "0.1"
 gloo = "0.8"
 uuid = { version = "1", features = ["serde", "v4", "wasm-bindgen"] }
-wasm-bindgen = "0.2"
+wasm-bindgen = { workspace = true }
 lazy_static = "1"
 log = "0.4"
 strum = "0.24"
 strum_macros = "0.24"
-serde = { version = "1", features = ["derive", "rc"]}
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 tera = "1"
 
 [dependencies.web-sys]
 version = "0.3"
-features = [
-	"Window",
-	"Document",
-	"HtmlElement",
-	"HtmlInputElement"
-]
+features = ["Window", "Document", "HtmlElement", "HtmlInputElement"]

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -10,5 +10,4 @@ log = "0.4"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.0"
-
+wasm-bindgen-test = { workspace = true }

--- a/examples/counters/Cargo.toml
+++ b/examples/counters/Cargo.toml
@@ -10,5 +10,4 @@ console_log = "0.2"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.0"
-
+wasm-bindgen-test = { workspace = true }

--- a/examples/counters_stable/Cargo.toml
+++ b/examples/counters_stable/Cargo.toml
@@ -10,5 +10,4 @@ console_log = "0.2"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.0"
-
+wasm-bindgen-test = { workspace = true }

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -13,5 +13,4 @@ console_log = "0.2"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.0"
-
+wasm-bindgen-test = { workspace = true }

--- a/examples/hackernews/Cargo.toml
+++ b/examples/hackernews/Cargo.toml
@@ -14,7 +14,9 @@ console_log = "0.2"
 console_error_panic_hook = "0.1"
 futures = "0.3"
 cfg-if = "1"
-leptos = { path = "../../leptos", default-features = false, features = ["serde"] }
+leptos = { path = "../../leptos", default-features = false, features = [
+	"serde",
+] }
 leptos_meta = { path = "../../meta", default-features = false }
 leptos_actix = { path = "../../integrations/actix", default-features = false, optional = true }
 leptos_router = { path = "../../router", default-features = false }
@@ -25,7 +27,7 @@ serde_json = "1"
 gloo-net = { version = "0.2", features = ["http"] }
 reqwest = { version = "0.11", features = ["json"] }
 # openssl = { version = "0.10", features = ["v110"] }
-wasm-bindgen = "0.2"
+wasm-bindgen = { workspace = true }
 web-sys = { version = "0.3", features = ["AbortController", "AbortSignal"] }
 tracing = "0.1"
 
@@ -47,26 +49,26 @@ skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
-output-name = "hackernews"	
+output-name = "hackernews"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written
 # Defaults to pkg	
-site-pkg-dir = "pkg" 	
+site-pkg-dir = "pkg"
 # [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
 style-file = "./style.css"
 # [Optional] Files in the asset-dir will be copied to the site-root directory
 # assets-dir = "static/assets"
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-address = "127.0.0.1:3000"	
+site-address = "127.0.0.1:3000"
 # The port to use for automatic reload monitoring
-reload-port = 3001	
+reload-port = 3001
 # [Optional] Command to use when running end2end tests. It will run in the end2end dir.
 end2end-cmd = "npx playwright test"
 #  The browserlist query used for optimizing the CSS.
-browserquery = "defaults" 	
+browserquery = "defaults"
 # Set by cargo-leptos watch when building with tha tool. Controls whether autoreload JS will be included in the head
-watch = false 	
+watch = false
 # The environment Leptos will run in, usually either "DEV" or "PROD"
 env = "DEV"
 # The features to use when compiling the bin target

--- a/examples/hackernews_axum/Cargo.toml
+++ b/examples/hackernews_axum/Cargo.toml
@@ -30,7 +30,7 @@ tower-http = { version = "0.3.4", features = ["fs"], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
 http = { version = "0.2.8", optional = true }
 web-sys = { version = "0.3", features = ["AbortController", "AbortSignal"] }
-wasm-bindgen = "0.2"
+wasm-bindgen = { workspace = true }
 tracing = "0.1"
 
 [features]
@@ -55,26 +55,26 @@ skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
-output-name = "hackernews_axum"	
+output-name = "hackernews_axum"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written
 # Defaults to pkg	
-site-pkg-dir = "pkg" 	
+site-pkg-dir = "pkg"
 # [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
 style-file = "./style.css"
 # [Optional] Files in the asset-dir will be copied to the site-root directory
 # assets-dir = "static/assets"
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-address = "127.0.0.1:3000"	
+site-address = "127.0.0.1:3000"
 # The port to use for automatic reload monitoring
-reload-port = 3001	
+reload-port = 3001
 # [Optional] Command to use when running end2end tests. It will run in the end2end dir.
 end2end-cmd = "npx playwright test"
 #  The browserlist query used for optimizing the CSS.
-browserquery = "defaults" 	
+browserquery = "defaults"
 # Set by cargo-leptos watch when building with tha tool. Controls whether autoreload JS will be included in the head
-watch = false 	
+watch = false
 # The environment Leptos will run in, usually either "DEV" or "PROD"
 env = "DEV"
 # The features to use when compiling the bin target

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -14,4 +14,4 @@ console_error_panic_hook = "0.1.7"
 leptos_meta = { path = "../../meta", features = ["csr"] }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.0"
+wasm-bindgen-test = { workspace = true }

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.0"
+wasm-bindgen-test = { workspace = true }
 
 [features]
 default = ["csr"]

--- a/leptos_dom/examples/test-bench/Cargo.toml
+++ b/leptos_dom/examples/test-bench/Cargo.toml
@@ -9,7 +9,7 @@ gloo = { version = "0.8", features = ["futures"] }
 leptos = { path = "../../../leptos", features = ["tracing"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-wasm-bindgen-futures = "0.4"
+wasm-bindgen-futures = { workspace = true }
 web-sys = "0.3"
 
 [workspace]

--- a/leptos_dom/examples/view-tests/Cargo.toml
+++ b/leptos_dom/examples/view-tests/Cargo.toml
@@ -10,5 +10,4 @@ log = "0.4"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.0"
-
+wasm-bindgen-test = { workspace = true }

--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -21,8 +21,8 @@ base64 = "0.13"
 thiserror = "1"
 tokio = { version = "1", features = ["rt"], optional = true }
 tracing = "0.1"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
 web-sys = { version = "0.3", features = [
   "DocumentFragment",
   "Element",

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -24,8 +24,8 @@ thiserror = "1"
 serde_urlencoded = "0.7"
 serde = "1"
 js-sys = { version = "0.3" }
-wasm-bindgen = { version = "0.2" }
-wasm-bindgen-futures = { version = "0.4" }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
 
 [dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
This is similar to #283 

I am slowly reducing the duplication of crates downloaded.

The following crates are used multiple times, and so have been moved them to root workspace 

```
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+wasm-bindgen-test = "0.3.0"
```